### PR TITLE
Fix DMD & Textbox RGB/BGR, and slightly washed out LUT color grading

### DIFF
--- a/glshader/DMDShader.glfx
+++ b/glshader/DMDShader.glfx
@@ -139,9 +139,9 @@ void main()
             vec4 rgba = texture(Texture0, uv); //!! lots of tex access by doing this all the time, but (tex) cache should be able to catch all of it
             color.rgb = vColor_Intensity.xyz * vColor_Intensity.w; //!! create function that resembles LUT from VPM?
             if (rgba.a != 0.0)
-                color.rgb *= rgba.bgr;
+                color.rgb *= rgba.rgb;
             else
-                color.rgb *= rgba.b * (255.9 / 100.);
+                color.rgb *= rgba.r * (255.9 / 100.);
 
             // simulate dot within the sampled texel
             vec2 dist = fract(uv*vRes_Alpha_time.xy) * 2.2 - 1.1;

--- a/glshader/DMDShaderVR.glfx
+++ b/glshader/DMDShaderVR.glfx
@@ -145,9 +145,9 @@ void main()
             vec4 rgba = texture(Texture0, uv); //!! lots of tex access by doing this all the time, but (tex) cache should be able to catch all of it
             color.rgb = vColor_Intensity.xyz * vColor_Intensity.w; //!! create function that resembles LUT from VPM?
             if (rgba.a != 0.0)
-                color.rgb *= rgba.bgr;
+                color.rgb *= rgba.rgb;
             else
-                color.rgb *= rgba.b * (255.9 / 100.);
+                color.rgb *= rgba.r * (255.9 / 100.);
 
             // simulate dot within the sampled texel
             vec2 dist = fract(uv*vRes_Alpha_time.xy) * 2.2 - 1.1;

--- a/glshader/FBShader.glfx
+++ b/glshader/FBShader.glfx
@@ -165,8 +165,8 @@ vec3 FBColorGrade(vec3 color)
    color.z *= 15.0;
 
    float x = (color.x + floor(color.z))/16.0;
-   vec3 lut1 = FBGamma(textureLod(Texture4, vec2(x,          color.y), 0).xyz); // two lookups to blend/lerp between blue 2D regions
-   vec3 lut2 = FBGamma(textureLod(Texture4, vec2(x+1.0/16.0, color.y), 0).xyz);
+   vec3 lut1 = textureLod(Texture4, vec2(x,          color.y), 0).xyz; // two lookups to blend/lerp between blue 2D regions
+   vec3 lut2 = textureLod(Texture4, vec2(x+1.0/16.0, color.y), 0).xyz;
    return mix(lut1,lut2, frac(color.z));
 }
 

--- a/pin/player.cpp
+++ b/pin/player.cpp
@@ -4394,7 +4394,14 @@ void Player::PostProcess(const bool ambientOcclusion)
 
    Texture * const pin = m_ptable->GetImage(m_ptable->m_imageColorGrade);
    if (pin)
-      m_pin3d.m_pd3dPrimaryDevice->FBShader->SetTexture(SHADER_Texture4, pin, false);
+   {
+       // Texture used for LUT color grading must be treated as if they were linear
+	   if (pin->m_pdsBuffer->m_format == BaseTexture::SRGB)
+		   pin->m_pdsBuffer->m_format = BaseTexture::RGB;
+       else if (pin->m_pdsBuffer->m_format == BaseTexture::SRGBA)
+           pin->m_pdsBuffer->m_format = BaseTexture::RGBA;
+       m_pin3d.m_pd3dPrimaryDevice->FBShader->SetTexture(SHADER_Texture4, pin, false);
+   }
    m_pin3d.m_pd3dPrimaryDevice->FBShader->SetBool(SHADER_color_grade, pin != nullptr);
    m_pin3d.m_pd3dPrimaryDevice->FBShader->SetBool(SHADER_do_dither, !m_ditherOff);
    m_pin3d.m_pd3dPrimaryDevice->FBShader->SetBool(SHADER_do_bloom, (m_ptable->m_bloom_strength > 0.0f && !m_bloomOff));

--- a/pintable.cpp
+++ b/pintable.cpp
@@ -853,9 +853,9 @@ STDMETHODIMP ScriptGlobalTable::put_DMDPixels(VARIANT pVal) // assumes VT_UI1 as
             delete g_pplayer->m_texdmd;
          }
 #ifdef DMD_UPSCALE
-         g_pplayer->m_texdmd = new BaseTexture(g_pplayer->m_dmd.x*3, g_pplayer->m_dmd.y*3, BaseTexture::SRGBA);
+         g_pplayer->m_texdmd = new BaseTexture(g_pplayer->m_dmd.x*3, g_pplayer->m_dmd.y*3, BaseTexture::RGBA);
 #else
-         g_pplayer->m_texdmd = new BaseTexture(g_pplayer->m_dmd.x, g_pplayer->m_dmd.y, BaseTexture::SRGBA);
+         g_pplayer->m_texdmd = new BaseTexture(g_pplayer->m_dmd.x, g_pplayer->m_dmd.y, BaseTexture::RGBA);
 #endif
       }
 
@@ -900,9 +900,9 @@ STDMETHODIMP ScriptGlobalTable::put_DMDColoredPixels(VARIANT pVal) //!! assumes 
             delete g_pplayer->m_texdmd;
          }
 #ifdef DMD_UPSCALE
-         g_pplayer->m_texdmd = new BaseTexture(g_pplayer->m_dmd.x*3, g_pplayer->m_dmd.y*3, BaseTexture::SRGBA);
+         g_pplayer->m_texdmd = new BaseTexture(g_pplayer->m_dmd.x*3, g_pplayer->m_dmd.y*3, BaseTexture::RGBA);
 #else
-         g_pplayer->m_texdmd = new BaseTexture(g_pplayer->m_dmd.x, g_pplayer->m_dmd.y, BaseTexture::SRGBA);
+         g_pplayer->m_texdmd = new BaseTexture(g_pplayer->m_dmd.x, g_pplayer->m_dmd.y, BaseTexture::RGBA);
 #endif
       }
 

--- a/textbox.cpp
+++ b/textbox.cpp
@@ -398,11 +398,14 @@ void Textbox::PreRenderText()
    {
       for (int l = 0; l < m_texture->width(); l++, dest++, bitsd++)
       {
-         const D3DCOLOR src = *bitsd;
-         if (m_d.m_transparent && ((src & 0xFFFFFFu) == m_d.m_backcolor))
-            *dest = 0x00000000; // set to black & alpha full transparent
-         else
-            *dest = src | 0xFF000000u;
+		  const D3DCOLOR src = *bitsd;
+		  if (m_d.m_transparent && ((src & 0xFFFFFFu) == m_d.m_backcolor))
+			  *dest = 0x00000000; // set to black & alpha full transparent
+		  else
+			  *dest = ((src & 0x000000FFu) << 16)
+			  | (src & 0x0000FF00u)
+			  | ((src & 0x0000FF0000u) >> 16)
+			  | 0xFF000000u;
       }
       dest += m_texture->pitch()/4 - m_texture->width();
    }


### PR DESCRIPTION
Leftover from previous PR:
- inverted RGB / BGR and DMD was sRGB instead of RGB (Fix https://github.com/vpinball/vpvr/issues/7)
- loading LUT as sRGB then applying gamme in shader leads to a slightly modified LUT causing slightly washed out colors (wouldn't have seen it myself, thanks VPW)