### PR TITLE
VR Preview mode

### DIFF
--- a/CrashHandler.cpp
+++ b/CrashHandler.cpp
@@ -121,7 +121,11 @@ namespace
 
    void WriteHeader(FILE* f)
    {
+#ifdef ENABLE_SDL
       fprintf(f, "Crash report VPX GL rev%i (%s)\n============\n", GIT_REVISION, GIT_SHA);
+#else
+      fprintf(f, "Crash report VPX rev%i (%s)\n============\n", GIT_REVISION, GIT_SHA);
+#endif
    }
 
    const char* GetExceptionString(DWORD exc)

--- a/RenderDevice.cpp
+++ b/RenderDevice.cpp
@@ -854,9 +854,9 @@ void RenderDevice::CreateDevice(int &refreshrate, UINT adapterIndex)
    int disp_x, disp_y, disp_w, disp_h;
    getDisplaySetupByID(m_adapter, disp_x, disp_y, disp_w, disp_h);
 
-   const VRPreviewMode vrPreview = m_stereo3D != STEREO_VR ? VRPREVIEW_DISABLED : (VRPreviewMode) LoadValueIntWithDefault(regKey[RegName::PlayerVR], "VRPreview"s, VRPREVIEW_LEFT);
+   const VRPreviewMode vrPreview = (VRPreviewMode) LoadValueIntWithDefault(regKey[RegName::PlayerVR], "VRPreview"s, VRPREVIEW_LEFT);
 
-   if (vrPreview != VRPREVIEW_DISABLED)
+   if ((m_stereo3D != STEREO_VR) || (vrPreview != VRPREVIEW_DISABLED))
       m_sdl_playfieldHwnd = SDL_CreateWindow(
          "Visual Pinball Player SDL", disp_x + (disp_w - m_width) / 2, disp_y + (disp_h - m_height) / 2, m_width, m_height,
          SDL_WINDOW_OPENGL | SDL_WINDOW_SHOWN | (m_fullscreen ? SDL_WINDOW_FULLSCREEN : 0));

--- a/RenderDevice.h
+++ b/RenderDevice.h
@@ -307,7 +307,6 @@ RenderDevice(const int width, const int height, const bool fullscreen, const int
    HRESULT Create3DFont(INT Height, UINT Width, UINT Weight, UINT MipLevels, BOOL Italic, DWORD CharSet, DWORD OutputPrecision, DWORD Quality, DWORD PitchAndFamily, LPCTSTR pFacename, FontHandle *ppFont);
 #endif
 
-   void DrawTexturedQuad();
    void DrawTexturedQuad(const Vertex3D_TexelOnly* vertices);
    void DrawFullscreenTexturedQuad();
    
@@ -316,6 +315,9 @@ RenderDevice(const int width, const int height, const bool fullscreen, const int
 
    void SetViewport(const ViewPort*);
    void GetViewport(ViewPort*);
+
+   void SetTransform(const TransformStateType p1, const Matrix3D* p2, const int count = 1);
+   void GetTransform(const TransformStateType p1, Matrix3D* p2, const int count = 1);
 
    void ForceAnisotropicFiltering(const bool enable) { m_force_aniso = enable; }
    void CompressTextures(const bool enable) { m_compress_textures = enable; }
@@ -327,6 +329,7 @@ RenderDevice(const int width, const int height, const bool fullscreen, const int
 
    //VR stuff
 #ifdef ENABLE_VR
+   bool IsVRReady() { return m_pHMD != nullptr; }
    void SetTransformVR();
    void UpdateVRPosition();
    void tableUp();

--- a/RenderDevice.h
+++ b/RenderDevice.h
@@ -322,11 +322,6 @@ RenderDevice(const int width, const int height, const bool fullscreen, const int
    void ForceAnisotropicFiltering(const bool enable) { m_force_aniso = enable; }
    void CompressTextures(const bool enable) { m_compress_textures = enable; }
 
-   unsigned int getBufwidth() const { return m_Buf_width; }
-   unsigned int getBufheight() const { return m_Buf_height; }
-   unsigned int getBufwidthBlur() const { return m_Buf_widthBlur; }
-   unsigned int getBufheightBlur() const { return m_Buf_heightBlur; }
-
    //VR stuff
 #ifdef ENABLE_VR
    bool IsVRReady() { return m_pHMD != nullptr; }
@@ -451,15 +446,6 @@ public:
 private:
    bool m_dwm_was_enabled;
    bool m_dwm_enabled;
-
-   unsigned int m_Buf_width;
-   unsigned int m_Buf_height;
-
-   unsigned int m_Buf_widthBlur;
-   unsigned int m_Buf_heightBlur;
-
-   unsigned int m_Buf_widthSS;
-   unsigned int m_Buf_heightSS;
 
    //VR/Stereo Stuff
 #ifdef ENABLE_VR

--- a/Sampler.h
+++ b/Sampler.h
@@ -44,6 +44,7 @@ public:
    int GetWidth() const { return m_width; }
    int GetHeight() const { return m_height; }
 
+public:
    bool m_dirty;
 
 private:

--- a/dialogs/VROptionsDialog.h
+++ b/dialogs/VROptionsDialog.h
@@ -16,9 +16,6 @@ protected:
 private:
    void AddToolTip(const char * const text, HWND parentHwnd, HWND toolTipHwnd, HWND controlHwnd);
    void ResetVideoPreferences();
-   void FillVideoModesList(const vector<VideoMode>& modes, const VideoMode* curSelMode = nullptr);
-
-   vector<VideoMode> allVideoModes;
 };
 
 #endif

--- a/pin/player.cpp
+++ b/pin/player.cpp
@@ -4698,11 +4698,13 @@ void Player::Render()
    }
 #endif
 
-   m_pin3d.m_pd3dPrimaryDevice->BeginScene();
-   m_pin3d.UpdateMatrices();
-   RenderDynamics();
-
-   m_pin3d.m_pd3dPrimaryDevice->EndScene();
+   if (!RenderStaticOnly())
+   {
+      m_pin3d.m_pd3dPrimaryDevice->BeginScene();
+      m_pin3d.UpdateMatrices();
+      RenderDynamics();
+      m_pin3d.m_pd3dPrimaryDevice->EndScene();
+   }
 
    m_pininput.ProcessKeys(/*sim_msec,*/ -(int)(timeforframe / 1000)); // trigger key events mainly for VPM<->VP rountrip
 

--- a/pin/player.h
+++ b/pin/player.h
@@ -13,6 +13,14 @@
 
 constexpr int DBG_SPRITE_SIZE = 1024;
 
+enum VRPreviewMode
+{
+   VRPREVIEW_DISABLED,
+   VRPREVIEW_LEFT,
+   VRPREVIEW_RIGHT,
+   VRPREVIEW_BOTH
+};
+
 // NOTE that the following four definitions need to be in sync in their order!
 enum EnumAssignKeys
 {
@@ -443,6 +451,7 @@ public:
    bool m_stereo3Denabled;
    bool m_stereo3DY;
    StereoMode m_stereo3D;
+   VRPreviewMode m_vrPreview;
 
    bool m_headTracking;
    float m_global3DContrast;

--- a/pin3d.cpp
+++ b/pin3d.cpp
@@ -788,7 +788,8 @@ Matrix3D ComputeLaybackTransform(const float layback)
 void Pin3D::UpdateMatrices()
 {
 #ifdef ENABLE_VR
-   if (m_stereo3D == STEREO_VR) {
+   if (m_stereo3D == STEREO_VR && m_pd3dPrimaryDevice->IsVRReady())
+   {
       m_pd3dPrimaryDevice->SetTransformVR();
       Shader::GetTransform(TRANSFORMSTATE_PROJECTION, m_proj.m_matProj, 2);
       Shader::GetTransform(TRANSFORMSTATE_VIEW, &m_proj.m_matView, 1);

--- a/resource.h
+++ b/resource.h
@@ -872,7 +872,8 @@
 #define IDS_INPUT                       551
 #define IDC_VR_OFFSET_Z                 551
 #define IDS_UNHIDEALL                   552
-#define IDC_VR_DISABLE_PREVIEW          552
+#define IDC_VR_PREVIEW                  552
+#define IDC_VR_PREVIEW_LABEL            600
 #define IDS_HIDE                        553
 #define IDC_VR_SCALE                    553
 #define IDC_MODIFY3DSTEREO              554

--- a/vpinball_eng.rc
+++ b/vpinball_eng.rc
@@ -14,7 +14,7 @@
 #undef APSTUDIO_READONLY_SYMBOLS
 
 /////////////////////////////////////////////////////////////////////////////
-// English (United States) resources
+// Anglais (États-Unis) resources
 
 #if !defined(AFX_RESOURCE_DLL) || defined(AFX_TARG_ENU)
 LANGUAGE LANG_ENGLISH, SUBLANG_ENGLISH_US
@@ -322,7 +322,7 @@ BEGIN
     LTEXT           "Rawnei",IDC_STATIC,48,162,32,8
 END
 
-IDD_VIDEO_OPTIONS DIALOGEX 0, 0, 353, 406
+IDD_VIDEO_OPTIONS DIALOGEX 0, 0, 353, 420
 STYLE DS_SETFONT | DS_MODALFRAME | WS_POPUP | WS_CAPTION | WS_SYSMENU
 CAPTION "Video/Graphics Options"
 FONT 8, "MS Sans Serif", 0, 0, 0x0
@@ -331,7 +331,10 @@ BEGIN
     LISTBOX         IDC_SIZELIST,14,31,129,78,LBS_NOINTEGRALHEIGHT | WS_VSCROLL | WS_TABSTOP
     CONTROL         "Use always FS backdrop settings",IDC_BG_SET,"Button",BS_AUTOCHECKBOX | WS_TABSTOP,14,113,131,10
     LTEXT           "Post-processed AA",IDC_STATIC,15,147,61,9
+    LTEXT           "Sharpen",IDC_STATIC,15,161,60,9
     COMBOBOX        IDC_FXAACB,76,145,65,100,CBS_DROPDOWNLIST | WS_VSCROLL | WS_TABSTOP
+    COMBOBOX        IDC_SHARPENCB,76,159,65,100,CBS_DROPDOWNLIST | WS_VSCROLL | WS_TABSTOP
+    CONTROL         "Brute-force 4x SSAA",IDC_AA_ALL_TABLES,"Button",BS_AUTOCHECKBOX | WS_TABSTOP,15,173,133,10
     CONTROL         "Enable ScaleFX for internal DMD",IDC_SCALE_FX_DMD,
                     "Button",BS_AUTOCHECKBOX | WS_TABSTOP,15,185,121,10
     CONTROL         "Stretch Ball with Table",IDC_StretchNo,"Button",BS_AUTORADIOBUTTON | WS_GROUP,16,223,83,10
@@ -343,7 +346,7 @@ BEGIN
     EDITTEXT        IDC_CORRECTION_X,31,267,40,12,ES_AUTOHSCROLL
     LTEXT           "Y",IDC_STATIC,84,269,8,8
     EDITTEXT        IDC_CORRECTION_Y,93,267,40,12,ES_AUTOHSCROLL
-    COMBOBOX        IDC_3D_STEREO,16,297,118,60,CBS_DROPDOWNLIST | WS_VSCROLL | WS_TABSTOP
+    COMBOBOX        IDC_3D_STEREO,15,300,118,60,CBS_DROPDOWNLIST | WS_VSCROLL | WS_TABSTOP
     CONTROL         "Use Y-Axis (Cabinet/Rotated Screen)",IDC_3D_STEREO_Y,
                     "Button",BS_AUTOCHECKBOX | WS_TABSTOP,15,315,125,10
     LTEXT           "Offset",IDC_STATIC,16,329,50,10
@@ -356,7 +359,7 @@ BEGIN
     EDITTEXT        IDC_3D_STEREO_CONTRAST,93,367,40,12,ES_RIGHT | ES_AUTOHSCROLL
     LTEXT           "Anaglyph Desaturation",IDC_STATIC,16,381,74,10
     EDITTEXT        IDC_3D_STEREO_DESATURATION,93,380,40,12,ES_RIGHT | ES_AUTOHSCROLL
-    CONTROL         "BAM Headtracking",IDC_HEADTRACKING,"Button",BS_AUTOCHECKBOX | WS_TABSTOP,16,364,77,10
+    CONTROL         "BAM Headtracking",IDC_HEADTRACKING,"Button",BS_AUTOCHECKBOX | WS_TABSTOP,16,399,77,10
     CONTROL         "Reflect Ball on Playfield",IDC_GLOBAL_REFLECTION_CHECK,
                     "Button",BS_AUTOCHECKBOX | WS_TABSTOP,159,18,86,10
     CONTROL         "Ball Trails/Motion Blur",IDC_GLOBAL_TRAIL_CHECK,"Button",BS_AUTOCHECKBOX | WS_TABSTOP,159,29,86,10
@@ -410,22 +413,21 @@ BEGIN
     PUSHBUTTON      "Reset to Defaults",IDC_DEFAULTS,154,368,61,14
     PUSHBUTTON      "Set for LowEnd PC",IDC_DEFAULTS_LOW,216,368,65,14
     PUSHBUTTON      "Set for HighEnd PC",IDC_DEFAULTS_HIGH,282,368,65,14
-    PUSHBUTTON      "Reset PlayerWindow Pos",IDC_RESET_WINDOW,154,387,88,14
-    DEFPUSHBUTTON   "OK",IDOK,245,387,50,14
-    PUSHBUTTON      "Cancel",IDCANCEL,297,387,50,14
-    GROUPBOX        "Display",IDC_STATIC,7,7,142,394
+    PUSHBUTTON      "Reset PlayerWindow Pos",IDC_RESET_WINDOW,154,401,88,14
+    DEFPUSHBUTTON   "OK",IDOK,245,401,50,14
+    PUSHBUTTON      "Cancel",IDCANCEL,297,401,50,14
+    GROUPBOX        "Display",IDC_STATIC,7,7,142,408
     GROUPBOX        "Ball Rendering",IDC_STATIC,154,7,94,109
-    GROUPBOX        "3D Stereo Output",IDC_STATIC,11,287,134,89
+    GROUPBOX        "3D Stereo Output",IDC_STATIC,12,289,132,107
     GROUPBOX        "Performance and Troubleshooting",IDC_STATIC,154,167,193,192
     GROUPBOX        "Max Texture Dimension (for low-end gfx boards)",IDC_STATIC,159,299,183,25
     LTEXT           "Elements Detail Level (decrease = performance)",IDC_STATIC,163,330,156,8
     GROUPBOX        "Ball aspect ratio for stretched Tables",IDC_STATIC,12,212,132,75
     GROUPBOX        "Automatic Night->Day cycle",IDC_STATIC,154,123,193,39
-    LTEXT           "(Cabinet/Rotated Screen usage)",IDC_STATIC,24,135,121,8
+    LTEXT           "(Cabinet/Rotated Screen usage)",IDC_STATIC,24,123,121,8
     GROUPBOX        "Fullscreen",IDC_STATIC,159,251,183,43
     LTEXT           "(post-processed Anti-Aliasing)",IDC_STATIC,29,195,101,8
-    GROUPBOX        "Anti-Aliasing",IDC_STATIC,12,147,132,64
-    LTEXT           "Offset",IDC_3D_STEREO_OFS_LABEL,17,326,50,10
+    GROUPBOX        "Anti-Aliasing",IDC_STATIC,12,135,132,74
 END
 
 IDD_FONTDIALOG DIALOG 0, 0, 316, 167
@@ -2184,69 +2186,68 @@ BEGIN
     PUSHBUTTON      "&Close",IDCANCEL,81,182,50,14
 END
 
-IDD_VR_OPTIONS DIALOGEX 0, 0, 353, 402
+IDD_VR_OPTIONS DIALOGEX 0, 0, 302, 312
 STYLE DS_SETFONT | DS_MODALFRAME | WS_POPUP | WS_CAPTION | WS_SYSMENU
 CAPTION "VR Options"
 FONT 8, "MS Sans Serif", 0, 0, 0x0
 BEGIN
-    COMBOBOX        IDC_DISPLAY_ID,14,16,129,60,CBS_DROPDOWNLIST | WS_VSCROLL | WS_TABSTOP
-    LISTBOX         IDC_SIZELIST,13,32,129,92,LBS_NOINTEGRALHEIGHT | WS_VSCROLL | WS_TABSTOP
-    CONTROL         "Disable VR Preview",IDC_VR_DISABLE_PREVIEW,"Button",BS_AUTOCHECKBOX | WS_TABSTOP,13,127,91,10
-    CONTROL         "",IDC_MSAASLIDER,"msctls_trackbar32",TBS_AUTOTICKS | TBS_TOP | WS_TABSTOP,16,162,122,20
-    LTEXT           "MSAA Samples (4x Rec.):",IDC_MSAASLIDER_LABEL,18,149,117,8
-    CONTROL         "",IDC_SSSLIDER,"msctls_trackbar32",TBS_AUTOTICKS | TBS_TOP | WS_TABSTOP,16,195,122,20
-    LTEXT           "Supersampling Factor:",IDC_SSSLIDER_LABEL,18,182,117,8
-    COMBOBOX        IDC_FXAACB,19,234,111,100,CBS_DROPDOWNLIST | WS_VSCROLL | WS_TABSTOP
-    LTEXT           "Post-processed Anti-Aliasing",IDC_PostProcessAA_Label,19,221,117,8
+    LTEXT           "VR Preview:",IDC_VR_PREVIEW_LABEL,162,10,38,10
+    COMBOBOX        IDC_VR_PREVIEW,204,7,85,100,CBS_DROPDOWNLIST | WS_VSCROLL | WS_TABSTOP
+    CONTROL         "",IDC_MSAASLIDER,"msctls_trackbar32",TBS_AUTOTICKS | TBS_TOP | WS_TABSTOP,15,68,122,20
+    LTEXT           "MSAA Samples (4x Rec.):",IDC_MSAASLIDER_LABEL,17,55,117,8
+    CONTROL         "",IDC_SSSLIDER,"msctls_trackbar32",TBS_AUTOTICKS | TBS_TOP | WS_TABSTOP,15,101,122,20
+    LTEXT           "Supersampling Factor:",IDC_SSSLIDER_LABEL,17,88,117,8
+    COMBOBOX        IDC_FXAACB,18,140,111,100,CBS_DROPDOWNLIST | WS_VSCROLL | WS_TABSTOP
+    LTEXT           "Post-processed Anti-Aliasing",IDC_PostProcessAA_Label,18,127,117,8
     CONTROL         "Enable ScaleFX for internal DMD",IDC_SCALE_FX_DMD,
-                    "Button",BS_AUTOCHECKBOX | WS_TABSTOP,19,251,121,10
-    LTEXT           "(post-processed Anti-Aliasing)",-1,29,261,101,8
-    CONTROL         "Scale table to width (in cm)",IDC_SCALE_TO_CM,"Button",BS_AUTOCHECKBOX | WS_TABSTOP,14,295,119,10
-    LTEXT           "Scaling",IDC_VR_SCALE_LABEL,17,309,50,10
-    EDITTEXT        IDC_VR_SCALE,93,307,40,12,ES_RIGHT | ES_AUTOHSCROLL
-    LTEXT           "VR Slope",IDC_VR_SLOPE_LABEL,16,321,50,10
-    EDITTEXT        IDC_VR_SLOPE,93,321,40,12,ES_RIGHT | ES_AUTOHSCROLL
-    LTEXT           "VR Table Orientation",IDC_3D_VR_ORIENTATION_LABEL,16,334,73,10
-    EDITTEXT        IDC_3D_VR_ORIENTATION,93,334,40,12,ES_RIGHT | ES_AUTOHSCROLL
-    LTEXT           "VR Table X",IDC_VR_OFFSET_X_LABEL,16,347,50,10
-    EDITTEXT        IDC_VR_OFFSET_X,93,347,40,12,ES_RIGHT | ES_AUTOHSCROLL
-    LTEXT           "VR Table Y",IDC_VR_OFFSET_Y_LABEL,16,360,50,10
-    EDITTEXT        IDC_VR_OFFSET_Y,93,360,40,12,ES_RIGHT | ES_AUTOHSCROLL
-    LTEXT           "VR Table Height",IDC_VR_OFFSET_Z_LABEL,16,373,75,10
-    EDITTEXT        IDC_VR_OFFSET_Z,93,373,40,12,ES_RIGHT | ES_AUTOHSCROLL
+                    "Button",BS_AUTOCHECKBOX | WS_TABSTOP,18,157,121,10
+    LTEXT           "(post-processed Anti-Aliasing)",-1,28,167,101,8
+    CONTROL         "Scale table to width (in cm)",IDC_SCALE_TO_CM,"Button",BS_AUTOCHECKBOX | WS_TABSTOP,162,50,119,10
+    LTEXT           "Scaling",IDC_VR_SCALE_LABEL,165,64,50,10
+    EDITTEXT        IDC_VR_SCALE,241,62,40,12,ES_RIGHT | ES_AUTOHSCROLL
+    LTEXT           "VR Slope",IDC_VR_SLOPE_LABEL,164,76,50,10
+    EDITTEXT        IDC_VR_SLOPE,241,76,40,12,ES_RIGHT | ES_AUTOHSCROLL
+    LTEXT           "VR Table Orientation",IDC_3D_VR_ORIENTATION_LABEL,164,89,73,10
+    EDITTEXT        IDC_3D_VR_ORIENTATION,241,89,40,12,ES_RIGHT | ES_AUTOHSCROLL
+    LTEXT           "VR Table X",IDC_VR_OFFSET_X_LABEL,164,102,50,10
+    EDITTEXT        IDC_VR_OFFSET_X,241,102,40,12,ES_RIGHT | ES_AUTOHSCROLL
+    LTEXT           "VR Table Y",IDC_VR_OFFSET_Y_LABEL,164,115,50,10
+    EDITTEXT        IDC_VR_OFFSET_Y,241,115,40,12,ES_RIGHT | ES_AUTOHSCROLL
+    LTEXT           "VR Table Height",IDC_VR_OFFSET_Z_LABEL,164,128,75,10
+    EDITTEXT        IDC_VR_OFFSET_Z,241,128,40,12,ES_RIGHT | ES_AUTOHSCROLL
     CONTROL         "Ball Reflection on Playfield",IDC_GLOBAL_REFLECTION_CHECK,
-                    "Button",BS_AUTOCHECKBOX | WS_TABSTOP,154,13,97,10
+                    "Button",BS_AUTOCHECKBOX | WS_TABSTOP,14,229,97,10
     CONTROL         "ScreenSpace Reflections",IDC_GLOBAL_SSREFLECTION_CHECK,
-                    "Button",BS_AUTOCHECKBOX | WS_TABSTOP,154,23,97,10
+                    "Button",BS_AUTOCHECKBOX | WS_TABSTOP,14,239,97,10
     CONTROL         "Reflect Dynamic Elements",IDC_GLOBAL_PFREFLECTION_CHECK,
-                    "Button",BS_AUTOCHECKBOX | WS_TABSTOP,154,33,97,10
-    LTEXT           "on Playfield (quality)",-1,164,43,80,10
-    GROUPBOX        "Ambient Occlusion",-1,253,7,94,38
-    CONTROL         "Enable",IDC_ENABLE_AO,"Button",BS_AUTOCHECKBOX | WS_TABSTOP,258,18,72,10
-    CONTROL         "Update in-game (quality)",IDC_DYNAMIC_AO,"Button",BS_AUTOCHECKBOX | WS_TABSTOP,258,29,87,10
-    LTEXT           "Visual Nudge Strength",-1,156,60,89,8
-    EDITTEXT        IDC_NUDGE_STRENGTH,253,59,36,12,ES_RIGHT | ES_AUTOHSCROLL
-    GROUPBOX        "Performance and Troubleshooting",-1,154,148,193,70
-    COMBOBOX        IDC_COMBO_TEXTURE,157,158,188,60,CBS_DROPDOWNLIST | WS_VSCROLL | WS_TABSTOP
-    COMBOBOX        IDC_COMBO_BLIT,157,174,188,60,CBS_DROPDOWNLIST | WS_VSCROLL | WS_TABSTOP
+                    "Button",BS_AUTOCHECKBOX | WS_TABSTOP,14,249,131,10
+    LTEXT           "on Playfield (quality)",-1,24,259,118,10
+    GROUPBOX        "Ambient Occlusion",-1,12,185,131,38
+    CONTROL         "Enable",IDC_ENABLE_AO,"Button",BS_AUTOCHECKBOX | WS_TABSTOP,17,196,72,10
+    CONTROL         "Update in-game (quality)",IDC_DYNAMIC_AO,"Button",BS_AUTOCHECKBOX | WS_TABSTOP,17,207,87,10
+    LTEXT           "Visual Nudge Strength",-1,14,272,89,8
+    EDITTEXT        IDC_NUDGE_STRENGTH,111,271,36,12,ES_RIGHT | ES_AUTOHSCROLL
+    GROUPBOX        "Performance and Troubleshooting",-1,154,150,139,86
+    COMBOBOX        IDC_COMBO_TEXTURE,157,160,130,60,CBS_DROPDOWNLIST | WS_VSCROLL | WS_TABSTOP
+    COMBOBOX        IDC_COMBO_BLIT,157,176,131,60,CBS_DROPDOWNLIST | WS_VSCROLL | WS_TABSTOP
     CONTROL         "Force Bloom Filter off (performance)",IDC_BLOOM_OFF,
-                    "Button",BS_AUTOCHECKBOX | WS_TABSTOP,162,190,127,10
-    LTEXT           "VR near plane",IDC_NEAR_LABEL,157,203,48,10
-    EDITTEXT        IDC_NEAR_PLANE,206,201,40,12,ES_RIGHT | ES_AUTOHSCROLL
-    LTEXT           "VR far plane",IDC_FAR_LABEL,255,203,40,10
-    EDITTEXT        IDC_FAR_PLANE,300,201,40,12,ES_RIGHT | ES_AUTOHSCROLL
-    COMBOBOX        IDC_BG_SOURCE,235,334,111,100,CBS_DROPDOWNLIST | WS_VSCROLL | WS_TABSTOP
-    RTEXT           "Backglass source",IDC_BG_MODE,165,337,67,10
-    COMBOBOX        IDC_DMD_SOURCE,235,350,111,100,CBS_DROPDOWNLIST | WS_VSCROLL | WS_TABSTOP
-    RTEXT           "DMD source",IDC_DMD_MODE,165,353,67,10
-    COMBOBOX        IDC_TURN_VR_ON,235,365,111,100,CBS_DROPDOWNLIST | WS_VSCROLL | WS_TABSTOP
-    RTEXT           "VR Mode",IDC_VR_MODE,165,368,67,10
-    PUSHBUTTON      "Reset to Defaults",IDC_DEFAULTS,154,381,63,14
-    DEFPUSHBUTTON   "OK",IDOK,240,381,50,14
-    PUSHBUTTON      "Cancel",IDCANCEL,297,381,50,14
-    GROUPBOX        "Display",-1,7,7,141,388
-    GROUPBOX        "Table Setup",-1,10,281,134,108
-    GROUPBOX        "Anti-Aliasing",-1,12,138,132,139
+                    "Button",BS_AUTOCHECKBOX | WS_TABSTOP,162,192,127,10
+    LTEXT           "VR near plane",IDC_NEAR_LABEL,157,205,48,10
+    EDITTEXT        IDC_NEAR_PLANE,206,203,40,12,ES_RIGHT | ES_AUTOHSCROLL
+    LTEXT           "VR far plane",IDC_FAR_LABEL,161,220,40,10
+    EDITTEXT        IDC_FAR_PLANE,206,218,40,12,ES_RIGHT | ES_AUTOHSCROLL
+    COMBOBOX        IDC_BG_SOURCE,214,243,78,100,CBS_DROPDOWNLIST | WS_VSCROLL | WS_TABSTOP
+    RTEXT           "Backglass source",IDC_BG_MODE,144,246,67,10
+    COMBOBOX        IDC_DMD_SOURCE,214,259,77,100,CBS_DROPDOWNLIST | WS_VSCROLL | WS_TABSTOP
+    RTEXT           "DMD source",IDC_DMD_MODE,144,262,67,10
+    COMBOBOX        IDC_TURN_VR_ON,61,8,88,100,CBS_DROPDOWNLIST | WS_VSCROLL | WS_TABSTOP
+    LTEXT           "VR Mode",IDC_VR_MODE,14,9,38,10
+    PUSHBUTTON      "Reset to Defaults",IDC_DEFAULTS,110,293,63,14
+    DEFPUSHBUTTON   "OK",IDOK,186,293,50,14
+    PUSHBUTTON      "Cancel",IDCANCEL,242,293,50,14
+    GROUPBOX        "Table Setup",-1,158,36,134,108
+    GROUPBOX        "Anti-Aliasing",-1,11,44,132,139
+    GROUPBOX        "Display",-1,8,33,141,253
 END
 
 IDD_SOUND_POSITION_DIALOG DIALOGEX 0, 0, 298, 183
@@ -2741,8 +2742,9 @@ BEGIN
 
     IDD_VR_OPTIONS, DIALOG
     BEGIN
-        RIGHTMARGIN, 351
-        BOTTOMMARGIN, 397
+        LEFTMARGIN, 7
+        RIGHTMARGIN, 296
+        BOTTOMMARGIN, 307
     END
 
     IDD_SOUND_POSITION_DIALOG, DIALOG
@@ -3783,6 +3785,11 @@ BEGIN
     0
 END
 
+IDD_VR_OPTIONS AFX_DIALOG_LAYOUT
+BEGIN
+    0
+END
+
 
 /////////////////////////////////////////////////////////////////////////////
 //
@@ -3797,29 +3804,11 @@ BEGIN
     IDS_TB_WALL             "Wall"
     IDS_TB_FLIPPER          "Flipper"
     IDS_TB_PLAY             "Play"
-    IDS_TB_LIGHTSEQ         "LightSeq"
-    IDS_TB_PRIMITIVE        "Primitive"
-    IDS_TB_PLUNGER          "Plunger"
-    IDS_TB_TEXTBOX          "TextBox"
-    IDS_TB_BUMPER           "Bumper"
-    IDS_TB_DISPREEL         "EMReel"
-    IDS_TB_TRIGGER          "Trigger"
-    IDS_TB_LIGHT            "Light"
-    IDS_TB_KICKER           "Kicker"
-    IDS_TB_TARGET           "Target"
-    IDS_TB_DECAL            "Decal"
-    IDS_TB_PROPERTIES       "Options"
-    IDS_TB_MAGNIFY          "Magnify"
-    IDS_TB_GATE             "Gate"
-    IDS_TB_FLASHER          "Flasher"
-    IDS_TB_SPINNER          "Spinner"
-    IDS_TB_RAMP             "Ramp"
-    IDS_TB_RUBBER           "Rubber"
-    IDS_TB_BACKGLASS        "Backglass/POV"
 END
 
 STRINGTABLE
 BEGIN
+    IDS_TB_LIGHTSEQ         "LightSeq"
     IDS_REPLACEALL          "Replaced"
     IDS_REPLACEALL2         "occurrences in script."
 END
@@ -3835,11 +3824,75 @@ BEGIN
     IDS_POSITION            "Position"
     IDS_STATE               "State & Physics"
     IDS_PHYSICS             "Physics"
+    IDS_TB_PRIMITIVE        "Primitive"
     IDS_VISUALS2            "Graphics & Camera"
     IDS_POSITION_TRANSLATION "Position & Translation"
     IDS_PASTE_ELEMENT       "Paste\tCtrl+V"
     IDS_PASTE_AT_ELEMENT    "Paste At\tCtrl+Shift+V"
     IDS_DELETE_ELEMENTS     "Selected elements are part of one or more collections.\nDo you really want to delete them?"
+END
+
+STRINGTABLE
+BEGIN
+    IDS_TB_PLUNGER          "Plunger"
+    IDS_FORMAT              "Format"
+    IDS_TB_TEXTBOX          "TextBox"
+    IDS_TB_BUMPER           "Bumper"
+    IDS_TB_DISPREEL         "EMReel"
+    IDS_TB_TRIGGER          "Trigger"
+END
+
+STRINGTABLE
+BEGIN
+    IDS_TB_LIGHT            "Light"
+    IDS_DRAWING_ORDER_HIT   "&Drawing Order (Hit)"
+    IDS_TB_KICKER           "Kicker"
+    IDS_TB_TARGET           "Target"
+    IDS_TB_DECAL            "Decal"
+    IDS_TB_PROPERTIES       "Options"
+    IDS_TB_MAGNIFY          "Magnify"
+    IDS_TB_GATE             "Gate"
+    IDS_TB_FLASHER          "Flasher"
+    IDS_TB_SPINNER          "Spinner"
+    IDS_TO_COLLECTION       "Add/Remove &Collection"
+END
+
+STRINGTABLE
+BEGIN
+    IDS_TB_RAMP             "Ramp"
+    IDS_TB_RUBBER           "Rubber"
+    IDS_NAME                "Name"
+    IDS_IMPORTPATH          "Import Path"
+    IDS_REPLACESOUND        "Are you sure you want to replace the selected sound(s)?"
+    IDS_REMOVESOUND         "Are you sure you want to remove the selected sound(s)?"
+    IDS_IMAGE_PREVIEW       "Image\n\nPreview"
+    IDS_REMOVEIMAGE         "Are you sure you want to remove the selected image(s)?"
+    IDS_REPLACEIMAGE        "Are you sure you want to replace the selected image(s)?"
+    IDS_TABLE               "Table"
+    IDS_SCRIPT              "Script"
+    IDS_SAVE_CHANGES1       "Table '"
+    IDS_SAVE_CHANGES2       "' has changed.  Do you want to save changes before exiting?"
+    IDS_DRAWINFRONT         "Draw In &Front"
+END
+
+STRINGTABLE
+BEGIN
+    IDS_DRAWINBACK          "Draw In &Back"
+    IDS_SAVEERROR           "There was an error saving the file."
+    IDS_TB_BACKGLASS        "Backglass/POV"
+    IDS_WRONGFILEVERSION    "This table was saved by a newer version of Visual Pinball. It's possible that it won't work well!"
+    IDS_NOPASTEINVIEW       "One or more of the objects on the clipboard can not be placed into the current view."
+    IDS_FINDLOOPED          "Passed the end of the file"
+    IDS_FINDFAILED          "Cannot find the string '"
+    IDS_SETASDEFAULT        "Set element parameters as new default"
+    IDS_FINDFAILED2         "'"
+    IDS_CONTROLPOINT        "Control Point"
+    IDS_REMOVEMATERIAL      "Are you sure you want to remove the selected material(s)?"
+    IDS_CORRUPTFILE         "This file is corrupt and can not be loaded."
+    IDS_UNSECURECONTROL1    "This table is attempting to create an object of type '"
+    IDS_UNSECURECONTROL2    "'.  This object may not be safe.  Do you want to allow this object to be created?  Only answer Yes if you trust the author of this table."
+    IDS_COLLECTION          "Collection"
+    IDS_DEFAULTPHYSICS      "Do you really want to reset physics settings?"
 END
 
 STRINGTABLE
@@ -3857,53 +3910,11 @@ END
 
 STRINGTABLE
 BEGIN
-    IDS_FORMAT              "Format"
-END
-
-STRINGTABLE
-BEGIN
-    IDS_DRAWING_ORDER_HIT   "&Drawing Order (Hit)"
-    IDS_TO_COLLECTION       "Add/Remove &Collection"
-END
-
-STRINGTABLE
-BEGIN
     IDS_IMAGE_RAW_SIZE      "Raw Size"
     IDS_SIZE                "Size"
     IDS_ASSIGN_TO_CURRENT_LAYER "&Assign to selected layer"
     IDS_ASSIGN_TO_LAYER2    "&Assign to layer"
     IDS_DRAWING_ORDER_SELECT "D&rawing Order (Select)"
-END
-
-STRINGTABLE
-BEGIN
-    IDS_NAME                "Name"
-    IDS_IMPORTPATH          "Import Path"
-    IDS_REPLACESOUND        "Are you sure you want to replace the selected sound(s)?"
-    IDS_REMOVESOUND         "Are you sure you want to remove the selected sound(s)?"
-    IDS_IMAGE_PREVIEW       "Image\n\nPreview"
-    IDS_REMOVEIMAGE         "Are you sure you want to remove the selected image(s)?"
-    IDS_REPLACEIMAGE        "Are you sure you want to replace the selected image(s)?"
-    IDS_TABLE               "Table"
-    IDS_SCRIPT              "Script"
-    IDS_SAVE_CHANGES1       "Table '"
-    IDS_SAVE_CHANGES2       "' has changed.  Do you want to save changes before exiting?"
-    IDS_DRAWINFRONT         "Draw In &Front"
-    IDS_DRAWINBACK          "Draw In &Back"
-    IDS_SAVEERROR           "There was an error saving the file."
-    IDS_WRONGFILEVERSION    "This table was saved by a newer version of Visual Pinball. It's possible that it won't work well!"
-    IDS_NOPASTEINVIEW       "One or more of the objects on the clipboard can not be placed into the current view."
-    IDS_FINDLOOPED          "Passed the end of the file"
-    IDS_FINDFAILED          "Cannot find the string '"
-    IDS_FINDFAILED2         "'"
-    IDS_SETASDEFAULT        "Set element parameters as new default"
-    IDS_CONTROLPOINT        "Control Point"
-    IDS_REMOVEMATERIAL      "Are you sure you want to remove the selected material(s)?"
-    IDS_CORRUPTFILE         "This file is corrupt and can not be loaded."
-    IDS_UNSECURECONTROL1    "This table is attempting to create an object of type '"
-    IDS_UNSECURECONTROL2    "'.  This object may not be safe.  Do you want to allow this object to be created?  Only answer Yes if you trust the author of this table."
-    IDS_COLLECTION          "Collection"
-    IDS_DEFAULTPHYSICS      "Do you really want to reset physics settings?"
 END
 
 STRINGTABLE
@@ -3923,7 +3934,7 @@ BEGIN
     IDS_STEP                "Step"
 END
 
-#endif    // English (United States) resources
+#endif    // Anglais (États-Unis) resources
 /////////////////////////////////////////////////////////////////////////////
 
 
@@ -3937,3 +3948,4 @@ END
 
 /////////////////////////////////////////////////////////////////////////////
 #endif    // not APSTUDIO_INVOKED
+


### PR DESCRIPTION
This PR is the result on working on issue https://github.com/vpinball/vpvr/issues/24: to allow reproducing, I tried to add a VR preview mode which actually shows VR rendering (atm it will default to desktop mode if no VR headset is found, even if VR mode is selected).

This PR contains the following changes:
- allows to run in VR mode even without a VR headset. In this case, it will render in VR but only displaying the VR preview window.
- allows to select what to preview between nothing/left eye/right eye/both eyes
- clean up the VR option dialog by removing the misleading unused options (and code) and making a layout update
- fix the z fighting bug in camera mode (VPX also has it, a PR for this will follow for VPX)
- align buffer sizes with VPX ones and make code consistent between the 2 codebases

This PR should be safe to be merged (I tested it with the different modes). Sadly I did not solved the https://github.com/vpinball/vpvr/issues/24 issue (can't reproduce), but things are more clean know and easier to debug without a headset.