### PR TITLE
Full shader/sampler cleanup, add static prerender, sync to latest VPX

### DIFF
--- a/RenderDevice.cpp
+++ b/RenderDevice.cpp
@@ -961,12 +961,12 @@ void RenderDevice::CreateDevice(int &refreshrate, UINT adapterIndex)
    // Retrieve a reference to the back buffer.
    m_pBackBuffer = new RenderTarget(this, fbWidth, fbHeight);
 
-   constexpr colorFormat renderBufferFormat = RGBA16F;
+   constexpr colorFormat renderBufferFormat = RGB16F;
    int m_width_aa = (int)(m_width * m_AAfactor);
    int m_height_aa = (int)(m_height * m_AAfactor);
 
    // alloc float buffer for rendering (optionally 2x2 res for manual super sampling)
-   m_pOffscreenBackBufferTexture = new RenderTarget(this, m_width_aa, m_height_aa, renderBufferFormat, true, true, m_stereo3D, "Fatal Error: unable to create render buffer!");
+   m_pOffscreenBackBufferTexture = new RenderTarget(this, m_width_aa, m_height_aa, renderBufferFormat, true, g_pplayer->m_MSAASamples > 1, m_stereo3D, "Fatal Error: unable to create render buffer!");
 
    // If we are doing MSAA we need a texture with the same dimensions as the Back Buffer to resolve the end result to, can also use it for Post-AA
    if (g_pplayer->m_MSAASamples > 1 || m_FXAA > 0)
@@ -2069,11 +2069,12 @@ void RenderDevice::SetRenderStateClipPlane0(const bool enabled)
    if (SetRenderStateCache(CLIPPLANEENABLE, enabled ? PLANE0 : 0)) return;
 
 #ifdef ENABLE_SDL
+   // FIXME reimplement clip plane
    // Basicshader already prepared with proper clipplane so just need to enable/disable it
-   if (enabled)
+   /* if (enabled)
       glEnable(GL_CLIP_DISTANCE0);
    else
-      glDisable(GL_CLIP_DISTANCE0);
+      glDisable(GL_CLIP_DISTANCE0);*/
 #else
    CHECKD3D(m_pD3DDevice->SetRenderState((D3DRENDERSTATETYPE)CLIPPLANEENABLE, enabled ? PLANE0 : 0));
 #endif 

--- a/RenderDevice.cpp
+++ b/RenderDevice.cpp
@@ -2196,12 +2196,13 @@ void RenderDevice::DrawIndexedPrimitiveVB(const PrimitiveTypes type, const DWORD
    m_stats_drawn_triangles += np;
    vb->bind(); // do not change order, this calls glBindVertexArray in GL, which must come before GL_ELEMENT_ARRAY_BUFFER!
    ib->bind();
+
 #ifdef ENABLE_SDL
    const int offset = ib->getOffset() + (ib->getIndexFormat() == IndexBuffer::FMT_INDEX16 ? 2 : 4) * startIndex;
    //glDrawElementsInstancedBaseVertex(type, indexCount, ib->getIndexFormat() == IndexBuffer::FMT_INDEX16 ? GL_UNSIGNED_SHORT : GL_UNSIGNED_INT, (void*)offset, m_stereo3D != STEREO_OFF ? 2 : 1, vb->getOffset() + startVertex); // Do instancing in geometry shader instead
    glDrawElementsBaseVertex(type, indexCount, ib->getIndexFormat() == IndexBuffer::FMT_INDEX16 ? GL_UNSIGNED_SHORT : GL_UNSIGNED_INT, (void*)offset, vb->getOffset() + startVertex);
 #else
-   VertexDeclaration * declaration = fvfToDecl(fvf);
+   VertexDeclaration* declaration = fvfToDecl(fvf);
    SetVertexDeclaration(declaration);
 
    // render

--- a/RenderDevice.cpp
+++ b/RenderDevice.cpp
@@ -933,6 +933,7 @@ void RenderDevice::CreateDevice(int &refreshrate, UINT adapterIndex)
 
    if (m_stereo3D == STEREO_VR)
    {
+#ifdef ENABLE_VR
       if (LoadValueBoolWithDefault(regKey[RegName::PlayerVR], "scaleToFixedWidth"s, false))
       {
          float width;
@@ -945,6 +946,7 @@ void RenderDevice::CreateDevice(int &refreshrate, UINT adapterIndex)
          m_scale = 0.000540425f; // Scale factor for VPUnits to Meters
       // Initialize VR, this will also override the render buffer size (m_width, m_height) to account for HMD render size and render the 2 eyes simultaneously
       InitVR();
+#endif
    }
    else if (m_stereo3D >= STEREO_ANAGLYPH_RC && m_stereo3D <= STEREO_ANAGLYPH_AB)
    {

--- a/RenderDevice.cpp
+++ b/RenderDevice.cpp
@@ -1104,7 +1104,7 @@ bool RenderDevice::LoadShaders()
 
    // Initialize uniform to default value
    if (shaderCompilationOkay)
-       basicShader->SetFlasherColorAlpha(vec4(1.0f, 1.0f, 1.0f, 1.0f));
+      basicShader->SetFlasherColorAlpha(vec4(1.0f, 1.0f, 1.0f, 1.0f));
 
    return shaderCompilationOkay;
 }

--- a/RenderDevice.cpp
+++ b/RenderDevice.cpp
@@ -946,6 +946,11 @@ void RenderDevice::CreateDevice(int &refreshrate, UINT adapterIndex)
       // Initialize VR, this will also override the render buffer size (m_width, m_height) to account for HMD render size and render the 2 eyes simultaneously
       InitVR();
    }
+   else if (m_stereo3D >= STEREO_ANAGLYPH_RC && m_stereo3D <= STEREO_ANAGLYPH_AB)
+   {
+      // For anaglyph stereo mode, we need to double the width since the 2 eye images are mixed by colors, each being at the resolution of the output.
+      m_width = m_width * 2;
+   }
 
    if (m_stereo3D == STEREO_VR || m_vsync > refreshrate)
       m_vsync = 0;

--- a/RenderDevice.h
+++ b/RenderDevice.h
@@ -383,7 +383,6 @@ public:
    bool         m_sharpen;
    unsigned int m_FXAA;
    int          m_BWrendering;
-   UINT         m_adapter;
 
 private:
    void DrawPrimitive(const PrimitiveTypes type, const DWORD fvf, const void* vertices, const DWORD vertexCount);
@@ -416,6 +415,8 @@ private:
    RenderTarget* m_pBloomBufferTexture;
    RenderTarget* m_pBloomTmpBufferTexture;
    RenderTarget* m_pMirrorTmpBufferTexture;
+
+   UINT m_adapter;      // index of the display adapter to use
 
    static constexpr DWORD TEXTURE_SAMPLERS = 8;
    static constexpr DWORD TEXTURE_STATE_CACHE_SIZE = 256;

--- a/RenderTarget.cpp
+++ b/RenderTarget.cpp
@@ -39,7 +39,7 @@ RenderTarget::RenderTarget(RenderDevice* rd, int width, int height)
 #endif
 }
 
-RenderTarget::RenderTarget(RenderDevice* rd, const int width, const int height, const colorFormat format, bool with_depth, bool use_MSAA, int stereo, char* failureMessage)
+RenderTarget::RenderTarget(RenderDevice* rd, const int width, const int height, const colorFormat format, bool with_depth, bool use_MSAA, StereoMode stereo, char* failureMessage)
 {
    m_is_back_buffer = false;
    m_rd = rd;
@@ -230,7 +230,8 @@ RenderTarget* RenderTarget::Duplicate()
 void RenderTarget::CopyTo(RenderTarget* dest)
 {
 #ifdef ENABLE_SDL
-   // FIXME unimplementd (only used to copy render target for static pass)
+   glBlitNamedFramebuffer(GetCoreFrameBuffer(), dest->GetCoreFrameBuffer(), 0, 0, GetWidth(), GetHeight(), 0, 0, dest->GetWidth(), dest->GetHeight(),
+      m_has_depth ? GL_COLOR_BUFFER_BIT | GL_DEPTH_BUFFER_BIT : GL_COLOR_BUFFER_BIT, GL_NEAREST);
 #else
    CHECKD3D(m_rd->GetCoreDevice()->StretchRect(m_color_surface, nullptr, dest->m_color_surface, nullptr, D3DTEXF_NONE));
    if (m_has_depth && dest->m_has_depth)

--- a/RenderTarget.cpp
+++ b/RenderTarget.cpp
@@ -256,9 +256,6 @@ void RenderTarget::Activate(bool ignoreStereo)
    }
    else
    {
-      Shader::setTextureDirty(m_color_tex);
-      if (m_has_depth)
-         Shader::setTextureDirty(m_depth_tex);
       if (ignoreStereo)
       {
          glViewport(0, 0, m_width, m_height);

--- a/RenderTarget.h
+++ b/RenderTarget.h
@@ -2,12 +2,13 @@
 
 #include "typedefs3D.h"
 class RenderDevice;
+enum StereoMode;
 
 class RenderTarget final
 {
 public:
    RenderTarget(RenderDevice* rd, int width = -1, int height = -1); // Default output render target
-   RenderTarget(RenderDevice* rd, const int width, const int height, const colorFormat format, bool with_depth, bool use_MSAA, int stereo, char* failureMessage);
+   RenderTarget(RenderDevice* rd, const int width, const int height, const colorFormat format, bool with_depth, bool use_MSAA, StereoMode stereo, char* failureMessage);
    ~RenderTarget();
 
    void Activate(bool ignoreStereo);
@@ -21,6 +22,10 @@ public:
 
    int GetWidth() const { return m_width; }
    int GetHeight() const { return m_height; }
+   StereoMode GetStereo() const { return m_stereo; }
+   bool IsMSAA() const { return m_use_mSAA; }
+   bool HasDepth() const { return m_has_depth; }
+   colorFormat GetColorFormat() const { return m_format; }
 
 #ifdef ENABLE_SDL
    GLuint GetCoreFrameBuffer() const { return m_framebuffer; }
@@ -32,7 +37,7 @@ private:
    int m_width;
    int m_height;
    colorFormat m_format;
-   int m_stereo;
+   StereoMode m_stereo;
    RenderDevice* m_rd;
    Sampler* m_color_sampler;
    Sampler* m_depth_sampler;

--- a/Sampler.cpp
+++ b/Sampler.cpp
@@ -2,7 +2,7 @@
 #include "Sampler.h"
 #include "RenderDevice.h"
 
-Sampler::Sampler(RenderDevice* rd, BaseTexture* const surf, const bool force_linear_rgb)
+Sampler::Sampler(RenderDevice* rd, BaseTexture* const surf, const bool force_linear_rgb, const SamplerAddressMode clampu, const SamplerAddressMode clampv, const SamplerFilter filter)
 {
    m_rd = rd;
    m_dirty = false;
@@ -10,6 +10,9 @@ Sampler::Sampler(RenderDevice* rd, BaseTexture* const surf, const bool force_lin
    m_ownTexture = true;
    m_width = surf->width();
    m_height = surf->height();
+   m_clampu = clampu;
+   m_clampv = clampv;
+   m_filter = filter;
 #ifdef ENABLE_SDL
    colorFormat format;
    if (surf->m_format == BaseTexture::SRGBA)
@@ -61,12 +64,15 @@ Sampler::Sampler(RenderDevice* rd, BaseTexture* const surf, const bool force_lin
 }
 
 #ifdef ENABLE_SDL
-Sampler::Sampler(RenderDevice* rd, GLuint glTexture, bool ownTexture, bool isMSAA, bool force_linear_rgb)
+Sampler::Sampler(RenderDevice* rd, GLuint glTexture, bool ownTexture, bool isMSAA, bool force_linear_rgb, const SamplerAddressMode clampu, const SamplerAddressMode clampv, const SamplerFilter filter)
 {
    m_rd = rd;
    m_dirty = false;
    m_isMSAA = isMSAA;
    m_ownTexture = ownTexture;
+   m_clampu = clampu;
+   m_clampv = clampv;
+   m_filter = filter;
    glGetTexLevelParameteriv(GL_TEXTURE_2D, 0, GL_TEXTURE_WIDTH, &m_width);
    glGetTexLevelParameteriv(GL_TEXTURE_2D, 0, GL_TEXTURE_HEIGHT, &m_height);
    int internal_format;
@@ -75,12 +81,15 @@ Sampler::Sampler(RenderDevice* rd, GLuint glTexture, bool ownTexture, bool isMSA
    m_texture = glTexture;
 }
 #else
-Sampler::Sampler(RenderDevice* rd, IDirect3DTexture9* dx9Texture, bool ownTexture, bool force_linear_rgb)
+Sampler::Sampler(RenderDevice* rd, IDirect3DTexture9* dx9Texture, bool ownTexture, bool force_linear_rgb, const SamplerAddressMode clampu, const SamplerAddressMode clampv, const SamplerFilter filter)
 {
    m_rd = rd;
    m_dirty = false;
    m_isMSAA = false;
    m_ownTexture = ownTexture;
+   m_clampu = clampu;
+   m_clampv = clampv;
+   m_filter = filter;
    D3DSURFACE_DESC desc;
    dx9Texture->GetLevelDesc(0, &desc);
    m_width = desc.Width;

--- a/Sampler.cpp
+++ b/Sampler.cpp
@@ -141,6 +141,16 @@ void Sampler::UpdateTexture(BaseTexture* const surf, const bool force_linear_rgb
 #endif
 }
 
+void Sampler::SetClamp(const SamplerAddressMode clampu, const SamplerAddressMode clampv)
+{
+   m_clampu = clampu;
+   m_clampv = clampv;
+}
+
+void Sampler::SetFilter(const SamplerFilter filter)
+{
+   m_filter = filter;
+}
 
 #ifdef ENABLE_SDL
 GLuint Sampler::CreateTexture(UINT Width, UINT Height, UINT Levels, colorFormat Format, void* data, int stereo)
@@ -218,6 +228,8 @@ GLuint Sampler::CreateTexture(UINT Width, UINT Height, UINT Levels, colorFormat 
    if (data)
    {
       glPixelStorei(GL_UNPACK_ALIGNMENT, 1);
+      // This line causes a false GLIntercept error log on OpenGL >= 403 since the image is initialized through TexStorage and not TexImage (expected by GLIntercept)
+      // InterceptImage::SetImageDirtyPost - Flagging an image as dirty when it is not ready/init?
       glTexSubImage2D(GL_TEXTURE_2D, 0, 0, 0, Width, Height, col_format, col_type, data);
       glGenerateMipmap(GL_TEXTURE_2D); // Generate mip-maps, when using TexStorage will generate same amount as specified in TexStorage, otherwise good idea to limit by GL_TEXTURE_MAX_LEVEL
    }

--- a/Sampler.h
+++ b/Sampler.h
@@ -5,15 +5,17 @@ class RenderDevice;
 
 enum SamplerFilter
 {
-   SF_NONE, // No mipmapping
+   SF_UNDEFINED, // Used for undefined default values
+   SF_NONE, // No filtering at all. DX: MIPFILTER = NONE; MAGFILTER = POINT; MINFILTER = POINT; / OpenGL Nearest/Nearest
    SF_POINT, // Point sampled (aka nearest mipmap) texture filtering.
-   SF_BILINEAR, // Bilinar texture filtering.
-   SF_TRILINEAR, // Trilinar texture filtering.
+   SF_BILINEAR, // Bilinar texture filtering (linear min/mag, no mipmapping). DX: MIPFILTER = NONE; MAGFILTER = LINEAR; MINFILTER = LINEAR;
+   SF_TRILINEAR, // Trilinar texture filtering (linear min/mag, with mipmapping). DX: MIPFILTER = LINEAR; MAGFILTER = LINEAR; MINFILTER = LINEAR;
    SF_ANISOTROPIC // Anisotropic texture filtering.
 };
 
 enum SamplerAddressMode
 {
+   SA_UNDEFINED, // Used for undefined default values
 #ifdef ENABLE_SDL
    SA_REPEAT = GL_REPEAT,
    SA_CLAMP = GL_CLAMP_TO_EDGE,

--- a/Sampler.h
+++ b/Sampler.h
@@ -15,11 +15,11 @@ enum SamplerFilter
 enum SamplerAddressMode
 {
 #ifdef ENABLE_SDL
-   SA_WRAP = GL_REPEAT,
+   SA_REPEAT = GL_REPEAT,
    SA_CLAMP = GL_CLAMP_TO_EDGE,
    SA_MIRROR = GL_MIRRORED_REPEAT
 #else
-   SA_WRAP,
+   SA_REPEAT,
    SA_CLAMP,
    SA_MIRROR
 #endif
@@ -28,21 +28,27 @@ enum SamplerAddressMode
 class Sampler
 {
 public:
-   Sampler(RenderDevice* rd, BaseTexture* const surf, const bool force_linear_rgb);
+   Sampler(RenderDevice* rd, BaseTexture* const surf, const bool force_linear_rgb, const SamplerAddressMode clampu = SA_CLAMP, const SamplerAddressMode clampv = SA_CLAMP, const SamplerFilter filter = SF_NONE);
 #ifdef ENABLE_SDL
-   Sampler(RenderDevice* rd, GLuint glTexture, bool ownTexture, bool isMSAA, bool force_linear_rgb);
+   Sampler(RenderDevice* rd, GLuint glTexture, bool ownTexture, bool isMSAA, bool force_linear_rgb, const SamplerAddressMode clampu = SA_CLAMP, const SamplerAddressMode clampv = SA_CLAMP, const SamplerFilter filter = SF_NONE);
    GLuint GetCoreTexture() const { return m_texture; }
 #else
-   Sampler(RenderDevice* rd, IDirect3DTexture9* dx9Texture, bool ownTexture, bool force_linear_rgb);
+   Sampler(RenderDevice* rd, IDirect3DTexture9* dx9Texture, bool ownTexture, bool force_linear_rgb, const SamplerAddressMode clampu = SA_CLAMP, const SamplerAddressMode clampv = SA_CLAMP, const SamplerFilter filter = SF_NONE);
    IDirect3DTexture9* GetCoreTexture() { return m_texture;  }
 #endif
    ~Sampler();
 
    void UpdateTexture(BaseTexture* const surf, const bool force_linear_rgb);
+   void SetClamp(const SamplerAddressMode clampu, const SamplerAddressMode clampv);
+   void SetFilter(const SamplerFilter filter);
+
    bool IsLinear() const { return m_isLinear; }
    bool IsMSAA() const { return m_isMSAA; }
    int GetWidth() const { return m_width; }
    int GetHeight() const { return m_height; }
+   SamplerFilter GetFilter() const { return m_filter; }
+   SamplerAddressMode GetClampU() const { return m_clampu; }
+   SamplerAddressMode GetClampV() const { return m_clampv; }
 
 public:
    bool m_dirty;
@@ -54,6 +60,9 @@ private:
    RenderDevice* m_rd;
    int m_width;
    int m_height;
+   SamplerAddressMode m_clampu;
+   SamplerAddressMode m_clampv;
+   SamplerFilter m_filter;
 #ifdef ENABLE_SDL
    GLuint m_texture = 0;
    GLuint CreateTexture(UINT Width, UINT Height, UINT Levels, colorFormat Format, void* data, int stereo);

--- a/Shader.cpp
+++ b/Shader.cpp
@@ -5,6 +5,132 @@
 #include "typedefs3D.h"
 #include "RenderDevice.h"
 
+#define SHADER_TECHNIQUE(name) #name,
+const string Shader::shaderTechniqueNames[SHADER_TECHNIQUE_COUNT]
+{
+   SHADER_TECHNIQUE(RenderBall)
+   SHADER_TECHNIQUE(RenderBall_DecalMode)
+   SHADER_TECHNIQUE(RenderBall_CabMode)
+   SHADER_TECHNIQUE(RenderBall_CabMode_DecalMode)
+   SHADER_TECHNIQUE(RenderBallTrail)
+   SHADER_TECHNIQUE(basic_without_texture)
+   SHADER_TECHNIQUE(basic_with_texture)
+   SHADER_TECHNIQUE(basic_depth_only_without_texture)
+   SHADER_TECHNIQUE(basic_depth_only_with_texture)
+   SHADER_TECHNIQUE(bg_decal_without_texture)
+   SHADER_TECHNIQUE(bg_decal_with_texture)
+   SHADER_TECHNIQUE(kickerBoolean)
+   SHADER_TECHNIQUE(light_with_texture)
+   SHADER_TECHNIQUE(light_without_texture)
+   SHADER_TECHNIQUE(basic_DMD)
+   SHADER_TECHNIQUE(basic_DMD_ext)
+   SHADER_TECHNIQUE(basic_DMD_world)
+   SHADER_TECHNIQUE(basic_DMD_world_ext)
+   SHADER_TECHNIQUE(basic_noDMD)
+   SHADER_TECHNIQUE(basic_noDMD_world)
+   SHADER_TECHNIQUE(basic_noDMD_notex)
+   SHADER_TECHNIQUE(AO)
+   SHADER_TECHNIQUE(NFAA)
+   SHADER_TECHNIQUE(DLAA_edge)
+   SHADER_TECHNIQUE(DLAA)
+   SHADER_TECHNIQUE(FXAA1)
+   SHADER_TECHNIQUE(FXAA2)
+   SHADER_TECHNIQUE(FXAA3)
+   SHADER_TECHNIQUE(fb_tonemap)
+   SHADER_TECHNIQUE(fb_bloom)
+   SHADER_TECHNIQUE(fb_AO)
+   SHADER_TECHNIQUE(fb_tonemap_AO)
+   SHADER_TECHNIQUE(fb_tonemap_AO_static)
+   SHADER_TECHNIQUE(fb_tonemap_no_filterRGB)
+   SHADER_TECHNIQUE(fb_tonemap_no_filterRG)
+   SHADER_TECHNIQUE(fb_tonemap_no_filterR)
+   SHADER_TECHNIQUE(fb_tonemap_AO_no_filter)
+   SHADER_TECHNIQUE(fb_tonemap_AO_no_filter_static)
+   SHADER_TECHNIQUE(fb_bloom_horiz9x9)
+   SHADER_TECHNIQUE(fb_bloom_vert9x9)
+   SHADER_TECHNIQUE(fb_bloom_horiz19x19)
+   SHADER_TECHNIQUE(fb_bloom_vert19x19)
+   SHADER_TECHNIQUE(fb_bloom_horiz19x19h)
+   SHADER_TECHNIQUE(fb_bloom_vert19x19h)
+   SHADER_TECHNIQUE(fb_bloom_horiz39x39)
+   SHADER_TECHNIQUE(fb_bloom_vert39x39)
+   SHADER_TECHNIQUE(SSReflection)
+   SHADER_TECHNIQUE(fb_mirror)
+   SHADER_TECHNIQUE(basic_noLight)
+   SHADER_TECHNIQUE(bulb_light)
+   SHADER_TECHNIQUE(SMAA_ColorEdgeDetection)
+   SHADER_TECHNIQUE(SMAA_BlendWeightCalculation)
+   SHADER_TECHNIQUE(SMAA_NeighborhoodBlending)
+   SHADER_TECHNIQUE(stereo_Int)
+   SHADER_TECHNIQUE(stereo_Flipped_Int)
+   SHADER_TECHNIQUE(stereo_Anaglyph)
+   SHADER_TECHNIQUE(stereo_AMD_DEBUG)
+};
+#undef SHADER_TECHNIQUE
+
+#define SHADER_UNIFORM(name) { #name, -1 },
+#define SHADER_SAMPLER(name, unit) { #name, unit},
+const Shader::ShaderUniform Shader::shaderUniformNames[SHADER_UNIFORM_COUNT] {
+   //Floats
+   SHADER_UNIFORM(RenderBall)
+   SHADER_UNIFORM(blend_modulate_vs_add)
+   SHADER_UNIFORM(alphaTestValue)
+   SHADER_UNIFORM(eye)
+   SHADER_UNIFORM(fKickerScale)
+   //Vectors and Float Arrays
+   SHADER_UNIFORM(Roughness_WrapL_Edge_Thickness)
+   SHADER_UNIFORM(cBase_Alpha)
+   SHADER_UNIFORM(lightCenter_maxRange)
+   SHADER_UNIFORM(lightColor2_falloff_power)
+   SHADER_UNIFORM(lightColor_intensity)
+   SHADER_UNIFORM(matrixBlock)
+   SHADER_UNIFORM(fenvEmissionScale_TexWidth)
+   SHADER_UNIFORM(invTableRes_playfield_height_reflection)
+   SHADER_UNIFORM(lightEmission)
+   SHADER_UNIFORM(lightPos)
+   SHADER_UNIFORM(orientation)
+   SHADER_UNIFORM(cAmbient_LightRange)
+   SHADER_UNIFORM(cClearcoat_EdgeAlpha)
+   SHADER_UNIFORM(cGlossy_ImageLerp)
+   SHADER_UNIFORM(fDisableLighting_top_below)
+   SHADER_UNIFORM(backBoxSize)
+   SHADER_UNIFORM(vColor_Intensity)
+   SHADER_UNIFORM(w_h_height)
+   SHADER_UNIFORM(alphaTestValueAB_filterMode_addBlend)
+   SHADER_UNIFORM(amount_blend_modulate_vs_add_flasherMode)
+   SHADER_UNIFORM(staticColor_Alpha)
+   SHADER_UNIFORM(ms_zpd_ya_td)
+   SHADER_UNIFORM(Anaglyph_DeSaturation_Contrast)
+   SHADER_UNIFORM(vRes_Alpha_time)
+   SHADER_UNIFORM(mirrorFactor)
+   SHADER_UNIFORM(SSR_bumpHeight_fresnelRefl_scale_FS)
+   SHADER_UNIFORM(AO_scale_timeblur)
+   //Integer and Bool
+   SHADER_UNIFORM(ignoreStereo)
+   SHADER_UNIFORM(disableLighting)
+   SHADER_UNIFORM(lightSources)
+   SHADER_UNIFORM(doNormalMapping)
+   SHADER_UNIFORM(is_metal)
+   SHADER_UNIFORM(color_grade)
+   SHADER_UNIFORM(do_bloom)
+   SHADER_UNIFORM(lightingOff)
+   SHADER_UNIFORM(objectSpaceNormalMap)
+   SHADER_UNIFORM(do_dither)
+   //Texture samplers
+   SHADER_SAMPLER(Texture0, 0)
+   SHADER_SAMPLER(Texture1, 1)
+   SHADER_SAMPLER(Texture2, 2)
+   SHADER_SAMPLER(Texture3, 3)
+   SHADER_SAMPLER(Texture4, 4)
+   SHADER_SAMPLER(edgesTex2D, -1)
+   SHADER_SAMPLER(blendTex2D, -1)
+   SHADER_SAMPLER(areaTex2D, -1)
+   SHADER_SAMPLER(searchTex2D, -1)
+};
+#undef SHADER_UNIFORM
+#undef SHADER_SAMPLER
+
+
 RenderDevice *Shader::m_renderDevice = nullptr;
 
 Shader* Shader::getCurrentShader() {
@@ -14,23 +140,23 @@ Shader* Shader::getCurrentShader() {
 Shader* Shader::m_currentShader = nullptr;
 int Shader::shaderCount = 0;
 
-Shader::Shader(RenderDevice *renderDevice) : currentMaterial(-FLT_MAX, -FLT_MAX, -FLT_MAX, -FLT_MAX, -FLT_MAX, -FLT_MAX, -FLT_MAX,
-   0xCCCCCCCC, 0xCCCCCCCC, 0xCCCCCCCC, false, false, -FLT_MAX, -FLT_MAX, -FLT_MAX, -FLT_MAX)
+Shader::Shader(RenderDevice *renderDevice) : currentMaterial(-FLT_MAX, -FLT_MAX, -FLT_MAX, -FLT_MAX, -FLT_MAX, -FLT_MAX, -FLT_MAX, 0xCCCCCCCC, 0xCCCCCCCC, 0xCCCCCCCC, false, false, -FLT_MAX, -FLT_MAX, -FLT_MAX, -FLT_MAX)
 {
    shaderCount++;
+   m_technique = nullptr;
    m_renderDevice = renderDevice;
 #ifndef ENABLE_SDL
    m_shader = 0;
 #else
    m_nullTexture = new Texture(new BaseTexture(1, 1, BaseTexture::RGB));
-#if defined(TWEAK_GL_SHADER)
    for (int i = 0; i < SHADER_UNIFORM_COUNT; ++i) {
       uniformFloat[i] = 0.0f;
       uniformFloatP[i] = { 0, nullptr };
       uniformInt[i] = 0;
       uniformTex[i] = 0;
    }
-#endif
+   for (int i = 0; i < SHADER_TECHNIQUE_COUNT; ++i)
+      m_techniques[i] = nullptr;
 #endif
    for (unsigned int i = 0; i < TEXTURESET_STATE_CACHE_SIZE; ++i)
       currentTexture[i] = 0;

--- a/Shader.cpp
+++ b/Shader.cpp
@@ -159,14 +159,16 @@ const Shader::ShaderUniform Shader::shaderUniformNames[SHADER_UNIFORM_COUNT] {
    SHADER_SAMPLER(tex_light_color, texSampler0, Texture0, 0, SA_UNDEFINED, SA_UNDEFINED, SF_UNDEFINED) // base texture
    // SHADER_SAMPLER(tex_env, texSampler1, Texture1, 1, SA_REPEAT, SA_CLAMP, SF_TRILINEAR) // environment [Shared with basic]
    // SHADER_SAMPLER(tex_diffuse_env, texSampler2, Texture2, 2, SA_REPEAT, SA_CLAMP, SF_BILINEAR) // diffuse environment contribution/radiance [Shared with basic]
+   // Stereo shader (VPVR only, combine the 2 rendered eyes into a single one)
+   SHADER_SAMPLER(tex_stereo_fb, texSampler0, Texture0, 0, SA_CLAMP, SA_CLAMP, SF_POINT) // Framebuffer (unfiltered)
    // SMAA shader
    // FIXME SMAA shader also use the color and colorGamma samplers. This has to be looked at more deeply for a clean implementation
-   SHADER_SAMPLER(edgesTex, edgesTex, edgesTex2D, 0, SA_CLAMP, SA_CLAMP, SF_TRILINEAR)
-   SHADER_SAMPLER(blendTex, blendTex, blendTex2D, 1, SA_CLAMP, SA_CLAMP, SF_TRILINEAR)
-   SHADER_SAMPLER(areaTex, areaTex, areaTex2D, 2, SA_CLAMP, SA_CLAMP, SF_TRILINEAR)
-   SHADER_SAMPLER(searchTex, searchTex, searchTex2D, 3, SA_CLAMP, SA_CLAMP, SF_BILINEAR) // Not that this should have a w address mode set to clamp as well
-   // Stereo shader (VPVR only, combine the 2 eyes renders into a single one)
-   SHADER_SAMPLER(tex_stereo_fb, texSampler0, Texture0, 0, SA_CLAMP, SA_CLAMP, SF_POINT) // Framebuffer (unfiltered)
+   SHADER_SAMPLER(smaa_colorTex, colorTex, colorTex, 0, SA_CLAMP, SA_CLAMP, SF_TRILINEAR)
+   SHADER_SAMPLER(smaa_colorGammaTex, colorGammaTex, colorGammaTex, 1, SA_CLAMP, SA_CLAMP, SF_TRILINEAR)
+   SHADER_SAMPLER(edgesTex, edgesTex, edgesTex2D, 2, SA_CLAMP, SA_CLAMP, SF_TRILINEAR)
+   SHADER_SAMPLER(blendTex, blendTex, blendTex2D, 3, SA_CLAMP, SA_CLAMP, SF_TRILINEAR)
+   SHADER_SAMPLER(areaTex, areaTex, areaTex2D, 4, SA_CLAMP, SA_CLAMP, SF_TRILINEAR)
+   SHADER_SAMPLER(searchTex, searchTex, searchTex2D, 5, SA_CLAMP, SA_CLAMP, SF_BILINEAR) // Not that this should have a w address mode set to clamp as well
 };
 #undef SHADER_UNIFORM
 #undef SHADER_TEXTURE

--- a/Shader.cpp
+++ b/Shader.cpp
@@ -68,16 +68,17 @@ const string Shader::shaderTechniqueNames[SHADER_TECHNIQUE_COUNT]
 };
 #undef SHADER_TECHNIQUE
 
-#define SHADER_UNIFORM(name) { #name, -1 },
-#define SHADER_SAMPLER(name, unit) { #name, unit},
+#define SHADER_UNIFORM(name) { #name, #name, ""s, -1, SA_UNDEFINED, SA_UNDEFINED, SF_UNDEFINED },
+#define SHADER_TEXTURE(name) { #name, #name, ""s, -1, SA_UNDEFINED, SA_UNDEFINED, SF_UNDEFINED },
+#define SHADER_SAMPLER(name, legacy_name, texture_ref, default_tex_unit, default_clampu, default_clampv, default_filter) { #name, #legacy_name, #texture_ref, default_tex_unit, default_clampu, default_clampv, default_filter },
 const Shader::ShaderUniform Shader::shaderUniformNames[SHADER_UNIFORM_COUNT] {
-   //Floats
+   // -- Floats --
    SHADER_UNIFORM(RenderBall)
    SHADER_UNIFORM(blend_modulate_vs_add)
    SHADER_UNIFORM(alphaTestValue)
    SHADER_UNIFORM(eye)
    SHADER_UNIFORM(fKickerScale)
-   //Vectors and Float Arrays
+   // -- Vectors and Float Arrays --
    SHADER_UNIFORM(Roughness_WrapL_Edge_Thickness)
    SHADER_UNIFORM(cBase_Alpha)
    SHADER_UNIFORM(lightCenter_maxRange)
@@ -105,7 +106,7 @@ const Shader::ShaderUniform Shader::shaderUniformNames[SHADER_UNIFORM_COUNT] {
    SHADER_UNIFORM(mirrorFactor)
    SHADER_UNIFORM(SSR_bumpHeight_fresnelRefl_scale_FS)
    SHADER_UNIFORM(AO_scale_timeblur)
-   //Integer and Bool
+   // -- Integer and Bool --
    SHADER_UNIFORM(ignoreStereo)
    SHADER_UNIFORM(disableLighting)
    SHADER_UNIFORM(lightSources)
@@ -116,18 +117,59 @@ const Shader::ShaderUniform Shader::shaderUniformNames[SHADER_UNIFORM_COUNT] {
    SHADER_UNIFORM(lightingOff)
    SHADER_UNIFORM(objectSpaceNormalMap)
    SHADER_UNIFORM(do_dither)
-   //Texture samplers
-   SHADER_SAMPLER(Texture0, 0)
-   SHADER_SAMPLER(Texture1, 1)
-   SHADER_SAMPLER(Texture2, 2)
-   SHADER_SAMPLER(Texture3, 3)
-   SHADER_SAMPLER(Texture4, 4)
-   SHADER_SAMPLER(edgesTex2D, -1)
-   SHADER_SAMPLER(blendTex2D, -1)
-   SHADER_SAMPLER(areaTex2D, -1)
-   SHADER_SAMPLER(searchTex2D, -1)
+   SHADER_UNIFORM(imageBackglassMode)
+   // -- Textures --
+   SHADER_TEXTURE(Texture0)
+   SHADER_TEXTURE(Texture1)
+   SHADER_TEXTURE(Texture2)
+   SHADER_TEXTURE(Texture3)
+   SHADER_TEXTURE(Texture4)
+   SHADER_TEXTURE(edgesTex2D)
+   SHADER_TEXTURE(blendTex2D)
+   SHADER_TEXTURE(areaTex2D)
+   SHADER_TEXTURE(searchTex2D)
+   // -- Samplers (a texture reference with sampling configuration) --
+   // DMD shader
+   SHADER_SAMPLER(tex_dmd, texSampler0, Texture0, 0, SA_MIRROR, SA_MIRROR, SF_NONE) // DMD
+   SHADER_SAMPLER(tex_sprite, texSampler1, Texture0, 0, SA_MIRROR, SA_MIRROR, SF_TRILINEAR) // Sprite
+   // Flasher shader
+   SHADER_SAMPLER(tex_flasher_A, texSampler0, Texture0, 0, SA_UNDEFINED, SA_UNDEFINED, SF_UNDEFINED) // base texture
+   SHADER_SAMPLER(tex_flasher_B, texSampler1, Texture1, 1, SA_CLAMP, SA_CLAMP, SF_TRILINEAR) // texB
+   // FB shader
+   SHADER_SAMPLER(tex_fb_unfiltered, texSampler4, Texture0, 0, SA_CLAMP, SA_CLAMP, SF_POINT) // Framebuffer (unfiltered)
+   SHADER_SAMPLER(tex_fb_filtered, texSampler5, Texture0, 0, SA_CLAMP, SA_CLAMP, SF_BILINEAR) // Framebuffer (filtered)
+   SHADER_SAMPLER(tex_mirror, texSamplerMirror, Texture0, 0, SA_CLAMP, SA_CLAMP, SF_BILINEAR) // base mirror texture
+   SHADER_SAMPLER(tex_bloom, texSamplerBloom, Texture1, 1, SA_CLAMP, SA_CLAMP, SF_BILINEAR) // Bloom
+   SHADER_SAMPLER(tex_ao, texSampler3, Texture3, 2, SA_CLAMP, SA_CLAMP, SF_BILINEAR) // AO Result
+   SHADER_SAMPLER(tex_depth, texSamplerDepth, Texture3, 2, SA_CLAMP, SA_CLAMP, SF_NONE) // Depth
+   SHADER_SAMPLER(tex_color_lut, texSampler6, Texture4, 2, SA_CLAMP, SA_CLAMP, SF_BILINEAR) // Color grade LUT
+   SHADER_SAMPLER(tex_ao_dither, texSamplerAOdither, Texture4, 3, SA_REPEAT, SA_REPEAT, SF_NONE) // AO dither
+   // Ball shader
+   SHADER_SAMPLER(tex_ball_color, texSampler0, Texture0, 0, SA_UNDEFINED, SA_UNDEFINED, SF_UNDEFINED) // base texture
+   SHADER_SAMPLER(tex_ball_playfield, texSampler1, Texture1, 1, SA_REPEAT, SA_REPEAT, SF_TRILINEAR) // playfield
+   //SHADER_SAMPLER(tex_diffuse_env, texSampler2, Texture2, 2, SA_REPEAT, SA_CLAMP, SF_BILINEAR) // diffuse environment contribution/radiance [Shared with basic]
+   SHADER_SAMPLER(tex_ball_decal, texSampler7, Texture3, 3, SA_REPEAT, SA_REPEAT, SF_TRILINEAR) // ball decal
+   // Basic shader
+   SHADER_SAMPLER(tex_base_color, texSampler0, Texture0, 0, SA_UNDEFINED, SA_UNDEFINED, SF_UNDEFINED) // base texture
+   SHADER_SAMPLER(tex_env, texSampler1, Texture1, 1, SA_REPEAT, SA_CLAMP, SF_TRILINEAR) // environment
+   SHADER_SAMPLER(tex_diffuse_env, texSampler2, Texture2, 2, SA_REPEAT, SA_CLAMP, SF_BILINEAR) // diffuse environment contribution/radiance
+   SHADER_SAMPLER(tex_base_transmission, texSamplerBL, Texture3, 3, SA_CLAMP, SA_CLAMP, SF_BILINEAR) // bulb light/transmission buffer texture
+   SHADER_SAMPLER(tex_base_normalmap, texSamplerN, Texture4, 4, SA_UNDEFINED, SA_UNDEFINED, SF_UNDEFINED) // normal map texture
+   // Classic light shader
+   SHADER_SAMPLER(tex_light_color, texSampler0, Texture0, 0, SA_UNDEFINED, SA_UNDEFINED, SF_UNDEFINED) // base texture
+   // SHADER_SAMPLER(tex_env, texSampler1, Texture1, 1, SA_REPEAT, SA_CLAMP, SF_TRILINEAR) // environment [Shared with basic]
+   // SHADER_SAMPLER(tex_diffuse_env, texSampler2, Texture2, 2, SA_REPEAT, SA_CLAMP, SF_BILINEAR) // diffuse environment contribution/radiance [Shared with basic]
+   // SMAA shader
+   // FIXME SMAA shader also use the color and colorGamma samplers. This has to be looked at more deeply for a clean implementation
+   SHADER_SAMPLER(edgesTex, edgesTex, edgesTex2D, 0, SA_CLAMP, SA_CLAMP, SF_TRILINEAR)
+   SHADER_SAMPLER(blendTex, blendTex, blendTex2D, 1, SA_CLAMP, SA_CLAMP, SF_TRILINEAR)
+   SHADER_SAMPLER(areaTex, areaTex, areaTex2D, 2, SA_CLAMP, SA_CLAMP, SF_TRILINEAR)
+   SHADER_SAMPLER(searchTex, searchTex, searchTex2D, 3, SA_CLAMP, SA_CLAMP, SF_BILINEAR) // Not that this should have a w address mode set to clamp as well
+   // Stereo shader (VPVR only, combine the 2 eyes renders into a single one)
+   SHADER_SAMPLER(tex_stereo_fb, texSampler0, Texture0, 0, SA_CLAMP, SA_CLAMP, SF_POINT) // Framebuffer (unfiltered)
 };
 #undef SHADER_UNIFORM
+#undef SHADER_TEXTURE
 #undef SHADER_SAMPLER
 
 

--- a/Shader.h
+++ b/Shader.h
@@ -236,7 +236,6 @@ private:
 
 #ifdef ENABLE_SDL
    string m_shaderCodeName;
-   Texture* m_nullTexture;
    struct attributeLoc
    {
       GLenum type;
@@ -273,10 +272,12 @@ private:
    string analyzeFunction(const char* shaderCodeName, const string& technique, const string& functionName, const robin_hood::unordered_map<string, string>& values);
    ShaderTechnique* compileGLShader(const string& fileNameRoot, string& shaderCodeName, const string& vertex, const string& geometry, const string& fragment);
 
+   void ApplyUniform(const ShaderUniforms uniformName);
+   
    float uniformFloat[SHADER_UNIFORM_COUNT];
    floatP uniformFloatP[SHADER_UNIFORM_COUNT];
    int uniformInt[SHADER_UNIFORM_COUNT];
-   int uniformTex[SHADER_UNIFORM_COUNT];
+   Sampler* uniformTex[SHADER_UNIFORM_COUNT];
    
    struct ShaderUniform
    {
@@ -294,12 +295,11 @@ private:
    shaderAttributes getAttributeByName(const string& name);
 
    static Matrix3D mWorld, mView, mProj[2];
+   Texture* m_nullTexture;
    static Sampler* noTexture;
    static Sampler* noTextureMSAA;
    static const float* zeroData;
-   static int nextTextureSlot;
-   static int* textureSlotList;
-   static int maxSlots;
+   int m_nextTextureSlot;
 
 public:
    void setAttributeFormat(const DWORD fvf);

--- a/Shader.h
+++ b/Shader.h
@@ -179,6 +179,8 @@ enum ShaderUniforms
    SHADER_SAMPLER(tex_light_color, texSampler0, Texture0, 0, SA_UNDEFINED, SA_UNDEFINED, SF_UNDEFINED) // base texture
    // SHADER_SAMPLER(tex_env, texSampler1, Texture1, 1, SA_REPEAT, SA_CLAMP, SF_TRILINEAR) // environment [Shared with basic]
    // SHADER_SAMPLER(tex_diffuse_env, texSampler2, Texture2, 2, SA_REPEAT, SA_CLAMP, SF_BILINEAR) // diffuse environment contribution/radiance [Shared with basic]
+   // Stereo shader (VPVR only, combine the 2 rendered eyes into a single one)
+   SHADER_SAMPLER(tex_stereo_fb, texSampler0, Texture0, 0, SA_CLAMP, SA_CLAMP, SF_POINT) // Framebuffer (unfiltered)
    // SMAA shader
    // FIXME SMAA shader also use the color and colorGamma samplers. This has to be looked at more deeply for a clean implementation
    SHADER_SAMPLER(smaa_colorTex, colorTex, colorTex, 0, SA_CLAMP, SA_CLAMP, SF_TRILINEAR)
@@ -187,8 +189,6 @@ enum ShaderUniforms
    SHADER_SAMPLER(blendTex, blendTex, blendTex2D, 3, SA_CLAMP, SA_CLAMP, SF_TRILINEAR)
    SHADER_SAMPLER(areaTex, areaTex, areaTex2D, 4, SA_CLAMP, SA_CLAMP, SF_TRILINEAR)
    SHADER_SAMPLER(searchTex, searchTex, searchTex2D, 5, SA_CLAMP, SA_CLAMP, SF_BILINEAR) // Not that this should have a w address mode set to clamp as well
-   // Stereo shader (VPVR only, combine the 2 eyes renders into a single one)
-   SHADER_SAMPLER(tex_stereo_fb, texSampler0, Texture0, 0, SA_CLAMP, SA_CLAMP, SF_POINT) // Framebuffer (unfiltered)
    SHADER_UNIFORM_COUNT, SHADER_UNIFORM_INVALID
 };
 #undef SHADER_UNIFORM

--- a/Shader.h
+++ b/Shader.h
@@ -174,7 +174,7 @@ public:
 #endif
    void Unload();
 
-   void Begin(const unsigned int pass);
+   void Begin();
    void End();
 
    void SetTexture(const ShaderUniforms texelName, Texture* texel, const TextureFilter filter, const bool clampU, const bool clampV, const bool force_linear_rgb);

--- a/Shader.h
+++ b/Shader.h
@@ -14,195 +14,151 @@
 #define _SECURE_SCL 0
 #define _HAS_ITERATOR_DEBUGGING 0
 
-#ifdef ENABLE_SDL
-#ifndef TWEAK_GL_SHADER
-#include <map>
-#endif
-#endif
-
 #include <string>
 
-#if defined(ENABLE_SDL) && defined(TWEAK_GL_SHADER)
-//!! Todo tweak Enums for uniforms and techniques to reuse same numbers in different shaders/techniques. Reduces the array sizes, but might be hard to debug.
-enum shaderUniforms {
+// Declaration of all available techniques (shader program)
+// When changed, this list must also be copied unchanged to Shader.cpp (for its implementation)
+#define SHADER_TECHNIQUE(name) SHADER_TECHNIQUE_##name,
+enum ShaderTechniques
+{
+   SHADER_TECHNIQUE(RenderBall)
+   SHADER_TECHNIQUE(RenderBall_DecalMode)
+   SHADER_TECHNIQUE(RenderBall_CabMode)
+   SHADER_TECHNIQUE(RenderBall_CabMode_DecalMode)
+   SHADER_TECHNIQUE(RenderBallTrail)
+   SHADER_TECHNIQUE(basic_without_texture)
+   SHADER_TECHNIQUE(basic_with_texture)
+   SHADER_TECHNIQUE(basic_depth_only_without_texture)
+   SHADER_TECHNIQUE(basic_depth_only_with_texture)
+   SHADER_TECHNIQUE(bg_decal_without_texture)
+   SHADER_TECHNIQUE(bg_decal_with_texture)
+   SHADER_TECHNIQUE(kickerBoolean)
+   SHADER_TECHNIQUE(light_with_texture)
+   SHADER_TECHNIQUE(light_without_texture)
+   SHADER_TECHNIQUE(basic_DMD)
+   SHADER_TECHNIQUE(basic_DMD_ext)
+   SHADER_TECHNIQUE(basic_DMD_world)
+   SHADER_TECHNIQUE(basic_DMD_world_ext)
+   SHADER_TECHNIQUE(basic_noDMD)
+   SHADER_TECHNIQUE(basic_noDMD_world)
+   SHADER_TECHNIQUE(basic_noDMD_notex)
+   SHADER_TECHNIQUE(AO)
+   SHADER_TECHNIQUE(NFAA)
+   SHADER_TECHNIQUE(DLAA_edge)
+   SHADER_TECHNIQUE(DLAA)
+   SHADER_TECHNIQUE(FXAA1)
+   SHADER_TECHNIQUE(FXAA2)
+   SHADER_TECHNIQUE(FXAA3)
+   SHADER_TECHNIQUE(fb_tonemap)
+   SHADER_TECHNIQUE(fb_bloom)
+   SHADER_TECHNIQUE(fb_AO)
+   SHADER_TECHNIQUE(fb_tonemap_AO)
+   SHADER_TECHNIQUE(fb_tonemap_AO_static)
+   SHADER_TECHNIQUE(fb_tonemap_no_filterRGB)
+   SHADER_TECHNIQUE(fb_tonemap_no_filterRG)
+   SHADER_TECHNIQUE(fb_tonemap_no_filterR)
+   SHADER_TECHNIQUE(fb_tonemap_AO_no_filter)
+   SHADER_TECHNIQUE(fb_tonemap_AO_no_filter_static)
+   SHADER_TECHNIQUE(fb_bloom_horiz9x9)
+   SHADER_TECHNIQUE(fb_bloom_vert9x9)
+   SHADER_TECHNIQUE(fb_bloom_horiz19x19)
+   SHADER_TECHNIQUE(fb_bloom_vert19x19)
+   SHADER_TECHNIQUE(fb_bloom_horiz19x19h)
+   SHADER_TECHNIQUE(fb_bloom_vert19x19h)
+   SHADER_TECHNIQUE(fb_bloom_horiz39x39)
+   SHADER_TECHNIQUE(fb_bloom_vert39x39)
+   SHADER_TECHNIQUE(SSReflection)
+   SHADER_TECHNIQUE(fb_mirror)
+   SHADER_TECHNIQUE(basic_noLight)
+   SHADER_TECHNIQUE(bulb_light)
+   SHADER_TECHNIQUE(SMAA_ColorEdgeDetection)
+   SHADER_TECHNIQUE(SMAA_BlendWeightCalculation)
+   SHADER_TECHNIQUE(SMAA_NeighborhoodBlending)
+   SHADER_TECHNIQUE(stereo_Int)
+   SHADER_TECHNIQUE(stereo_Flipped_Int)
+   SHADER_TECHNIQUE(stereo_Anaglyph)
+   SHADER_TECHNIQUE(stereo_AMD_DEBUG)
+   SHADER_TECHNIQUE_COUNT, SHADER_TECHNIQUE_INVALID
+};
+#undef SHADER_TECHNIQUE
+
+// Declaration of all uniforms and samplers used in the shaders
+// When changed, this list must also be copied unchanged to Shader.cpp (for its implementation)
+#define SHADER_UNIFORM(name) SHADER_##name,
+#define SHADER_SAMPLER(name, unit) SHADER_##name,
+enum ShaderUniforms
+{
    //Floats
-   SHADER_blend_modulate_vs_add, SHADER_alphaTestValue, SHADER_eye, SHADER_fKickerScale,
+   SHADER_UNIFORM(RenderBall)
+   SHADER_UNIFORM(blend_modulate_vs_add)
+   SHADER_UNIFORM(alphaTestValue)
+   SHADER_UNIFORM(eye)
+   SHADER_UNIFORM(fKickerScale)
    //Vectors and Float Arrays
-   SHADER_Roughness_WrapL_Edge_Thickness, SHADER_cBase_Alpha, SHADER_lightCenter_maxRange, SHADER_lightColor2_falloff_power, SHADER_lightColor_intensity, SHADER_matrixBlock, SHADER_fenvEmissionScale_TexWidth,
-   SHADER_invTableRes_playfield_height_reflection, SHADER_lightEmission, SHADER_lightPos, SHADER_orientation, SHADER_cAmbient_LightRange, SHADER_cClearcoat_EdgeAlpha, SHADER_cGlossy_ImageLerp,
-   SHADER_fDisableLighting_top_below, SHADER_backBoxSize, SHADER_vColor_Intensity, SHADER_w_h_height, SHADER_alphaTestValueAB_filterMode_addBlend,
-   SHADER_amount_blend_modulate_vs_add_flasherMode, SHADER_staticColor_Alpha, SHADER_ms_zpd_ya_td, SHADER_Anaglyph_DeSaturation_Contrast, SHADER_vRes_Alpha_time, SHADER_mirrorFactor, SHADER_SSR_bumpHeight_fresnelRefl_scale_FS, SHADER_AO_scale_timeblur,
+   SHADER_UNIFORM(Roughness_WrapL_Edge_Thickness)
+   SHADER_UNIFORM(cBase_Alpha)
+   SHADER_UNIFORM(lightCenter_maxRange)
+   SHADER_UNIFORM(lightColor2_falloff_power)
+   SHADER_UNIFORM(lightColor_intensity)
+   SHADER_UNIFORM(matrixBlock)
+   SHADER_UNIFORM(fenvEmissionScale_TexWidth)
+   SHADER_UNIFORM(invTableRes_playfield_height_reflection)
+   SHADER_UNIFORM(lightEmission)
+   SHADER_UNIFORM(lightPos)
+   SHADER_UNIFORM(orientation)
+   SHADER_UNIFORM(cAmbient_LightRange)
+   SHADER_UNIFORM(cClearcoat_EdgeAlpha)
+   SHADER_UNIFORM(cGlossy_ImageLerp)
+   SHADER_UNIFORM(fDisableLighting_top_below)
+   SHADER_UNIFORM(backBoxSize)
+   SHADER_UNIFORM(vColor_Intensity)
+   SHADER_UNIFORM(w_h_height)
+   SHADER_UNIFORM(alphaTestValueAB_filterMode_addBlend)
+   SHADER_UNIFORM(amount_blend_modulate_vs_add_flasherMode)
+   SHADER_UNIFORM(staticColor_Alpha)
+   SHADER_UNIFORM(ms_zpd_ya_td)
+   SHADER_UNIFORM(Anaglyph_DeSaturation_Contrast)
+   SHADER_UNIFORM(vRes_Alpha_time)
+   SHADER_UNIFORM(mirrorFactor)
+   SHADER_UNIFORM(SSR_bumpHeight_fresnelRefl_scale_FS)
+   SHADER_UNIFORM(AO_scale_timeblur)
    //Integer and Bool
-   SHADER_ignoreStereo, SHADER_disableLighting, SHADER_lightSources, SHADER_doNormalMapping, SHADER_is_metal, SHADER_color_grade, SHADER_do_bloom, SHADER_lightingOff, SHADER_objectSpaceNormalMap, SHADER_do_dither,
-   //Textures
-   SHADER_Texture0, SHADER_Texture1, SHADER_Texture2, SHADER_Texture3, SHADER_Texture4, SHADER_edgesTex2D, SHADER_blendTex2D, SHADER_areaTex2D, SHADER_searchTex2D,
+   SHADER_UNIFORM(ignoreStereo)
+   SHADER_UNIFORM(disableLighting)
+   SHADER_UNIFORM(lightSources)
+   SHADER_UNIFORM(doNormalMapping)
+   SHADER_UNIFORM(is_metal)
+   SHADER_UNIFORM(color_grade)
+   SHADER_UNIFORM(do_bloom)
+   SHADER_UNIFORM(lightingOff)
+   SHADER_UNIFORM(objectSpaceNormalMap)
+   SHADER_UNIFORM(do_dither)
+   //Texture samplers
+   SHADER_SAMPLER(Texture0, 0)
+   SHADER_SAMPLER(Texture1, 1)
+   SHADER_SAMPLER(Texture2, 2)
+   SHADER_SAMPLER(Texture3, 3)
+   SHADER_SAMPLER(Texture4, 4)
+   SHADER_SAMPLER(edgesTex2D, -1)
+   SHADER_SAMPLER(blendTex2D, -1)
+   SHADER_SAMPLER(areaTex2D, -1)
+   SHADER_SAMPLER(searchTex2D, -1)
    SHADER_UNIFORM_COUNT, SHADER_UNIFORM_INVALID
 };
+#undef SHADER_UNIFORM
+#undef SHADER_SAMPLER
 
+#ifdef ENABLE_SDL
 enum shaderAttributes {
    SHADER_ATTRIBUTE_POS, SHADER_ATTRIBUTE_NORM, SHADER_ATTRIBUTE_TC, SHADER_ATTRIBUTE_TEX,
    SHADER_ATTRIBUTE_COUNT, SHADER_ATTRIBUTE_INVALID
 };
-
-enum shaderTechniques {
-   SHADER_TECHNIQUE_RenderBall, SHADER_TECHNIQUE_RenderBall_DecalMode, SHADER_TECHNIQUE_RenderBall_CabMode, SHADER_TECHNIQUE_RenderBall_CabMode_DecalMode, SHADER_TECHNIQUE_RenderBallTrail,
-   SHADER_TECHNIQUE_basic_without_texture, SHADER_TECHNIQUE_basic_with_texture, SHADER_TECHNIQUE_basic_depth_only_without_texture, SHADER_TECHNIQUE_basic_depth_only_with_texture, SHADER_TECHNIQUE_bg_decal_without_texture,
-   SHADER_TECHNIQUE_bg_decal_with_texture, SHADER_TECHNIQUE_kickerBoolean, SHADER_TECHNIQUE_light_with_texture, SHADER_TECHNIQUE_light_without_texture,
-   SHADER_TECHNIQUE_basic_DMD, SHADER_TECHNIQUE_basic_DMD_ext, SHADER_TECHNIQUE_basic_DMD_world, SHADER_TECHNIQUE_basic_DMD_world_ext, SHADER_TECHNIQUE_basic_noDMD, SHADER_TECHNIQUE_basic_noDMD_world, SHADER_TECHNIQUE_basic_noDMD_notex,
-   SHADER_TECHNIQUE_AO, SHADER_TECHNIQUE_NFAA, SHADER_TECHNIQUE_DLAA_edge, SHADER_TECHNIQUE_DLAA, SHADER_TECHNIQUE_FXAA1, SHADER_TECHNIQUE_FXAA2, SHADER_TECHNIQUE_FXAA3, SHADER_TECHNIQUE_fb_tonemap, SHADER_TECHNIQUE_fb_bloom,
-   SHADER_TECHNIQUE_fb_AO, SHADER_TECHNIQUE_fb_tonemap_AO, SHADER_TECHNIQUE_fb_tonemap_AO_static, SHADER_TECHNIQUE_fb_tonemap_no_filterRGB, SHADER_TECHNIQUE_fb_tonemap_no_filterRG, SHADER_TECHNIQUE_fb_tonemap_no_filterR, 
-   SHADER_TECHNIQUE_fb_tonemap_AO_no_filter, SHADER_TECHNIQUE_fb_tonemap_AO_no_filter_static, SHADER_TECHNIQUE_fb_bloom_horiz9x9, SHADER_TECHNIQUE_fb_bloom_vert9x9, SHADER_TECHNIQUE_fb_bloom_horiz19x19, SHADER_TECHNIQUE_fb_bloom_vert19x19,
-   SHADER_TECHNIQUE_fb_bloom_horiz19x19h, SHADER_TECHNIQUE_fb_bloom_vert19x19h, SHADER_TECHNIQUE_fb_bloom_horiz39x39, SHADER_TECHNIQUE_fb_bloom_vert39x39, SHADER_TECHNIQUE_SSReflection, SHADER_TECHNIQUE_fb_mirror, SHADER_TECHNIQUE_basic_noLight, SHADER_TECHNIQUE_bulb_light,
-   SHADER_TECHNIQUE_SMAA_ColorEdgeDetection, SHADER_TECHNIQUE_SMAA_BlendWeightCalculation, SHADER_TECHNIQUE_SMAA_NeighborhoodBlending,
-   SHADER_TECHNIQUE_stereo_Int, SHADER_TECHNIQUE_stereo_Flipped_Int, SHADER_TECHNIQUE_stereo_Anaglyph, SHADER_TECHNIQUE_stereo_AMD_DEBUG,
-   SHADER_TECHNIQUE_COUNT, SHADER_TECHNIQUE_INVALID
-};
-
-typedef shaderUniforms SHADER_UNIFORM_HANDLE;
-typedef shaderTechniques SHADER_TECHNIQUE_HANDLE;
-typedef void ID3DXEffect;
-
 #else
-
-//Float
-#define SHADER_blend_modulate_vs_add "blend_modulate_vs_add"
-#define SHADER_alphaTestValue "alphaTestValue"
-#define SHADER_eye "eye"
-#define SHADER_fKickerScale "fKickerScale"
-
-//Vectors and Float Arrays
-#define SHADER_Roughness_WrapL_Edge_Thickness "Roughness_WrapL_Edge_Thickness"
-#define SHADER_cBase_Alpha "cBase_Alpha"
-#define SHADER_lightCenter_maxRange "lightCenter_maxRange"
-#define SHADER_lightColor2_falloff_power "lightColor2_falloff_power"
-#define SHADER_lightColor_intensity "lightColor_intensity"
-#define SHADER_matrixBlock "matrixBlock"
-#define SHADER_fenvEmissionScale_TexWidth "fenvEmissionScale_TexWidth"
-#define SHADER_invTableRes_playfield_height_reflection "invTableRes_playfield_height_reflection"
-#define SHADER_lightEmission "lightEmission"
-#define SHADER_lightPos "lightPos"
-#define SHADER_orientation "orientation"
-#define SHADER_cAmbient_LightRange "cAmbient_LightRange"
-#define SHADER_cClearcoat_EdgeAlpha "cClearcoat_EdgeAlpha"
-#define SHADER_cGlossy_ImageLerp "cGlossy_ImageLerp"
-#define SHADER_fDisableLighting_top_below "fDisableLighting_top_below"
-#define SHADER_backBoxSize "backBoxSize"
-#define SHADER_quadOffsetScale "quadOffsetScale"
-#define SHADER_quadOffsetScaleTex "quadOffsetScaleTex"
-#define SHADER_vColor_Intensity "vColor_Intensity"
-#define SHADER_w_h_height "w_h_height"
-#define SHADER_alphaTestValueAB_filterMode_addBlend "alphaTestValueAB_filterMode_addBlend"
-#define SHADER_amount_blend_modulate_vs_add_flasherMode "amount_blend_modulate_vs_add_flasherMode"
-#define SHADER_staticColor_Alpha "staticColor_Alpha"
-#define SHADER_width_height_rotated_flipLR "width_height_rotated_flipLR"
-#define SHADER_vRes_Alpha_time "vRes_Alpha_time"
-#define SHADER_mirrorFactor "mirrorFactor"
-#define SHADER_SSR_bumpHeight_fresnelRefl_scale_FS "SSR_bumpHeight_fresnelRefl_scale_FS"
-#define SHADER_AO_scale_timeblur "AO_scale_timeblur"
-
-//Integer
-#define SHADER_ignoreStereo "ignoreStereo"
-#define SHADER_disableLighting "disableLighting"
-#define SHADER_lightSources "lightSources"
-#define SHADER_doNormalMapping "doNormalMapping"
-#define SHADER_is_metal "is_metal"
-#define SHADER_color_grade "color_grade"
-#define SHADER_do_bloom "do_bloom"
-#define SHADER_lightingOff "lightingOff"
-#define SHADER_objectSpaceNormalMap "objectSpaceNormalMap"
-#define SHADER_do_dither "do_dither"
-
-//Textures
-#define SHADER_Texture0 "Texture0"
-#define SHADER_Texture1 "Texture1"
-#define SHADER_Texture2 "Texture2"
-#define SHADER_Texture3 "Texture3"
-#define SHADER_Texture4 "Texture4"
-#define SHADER_edgesTex2D "edgesTex2D"
-#define SHADER_blendTex2D "blendTex2D"
-#define SHADER_areaTex2D "areaTex2D"
-#define SHADER_searchTex2D "searchTex2D"
-
 //Attributes
 #define SHADER_ATTRIBUTE_POS "vPosition"
 #define SHADER_ATTRIBUTE_NORM "vNormal"
 #define SHADER_ATTRIBUTE_TC "tc"
 #define SHADER_ATTRIBUTE_TEX "tex0"
-
-//Shader Techniques
-#define SHADER_TECHNIQUE_RenderBall "RenderBall"
-#define SHADER_TECHNIQUE_RenderBall_DecalMode "RenderBall_DecalMode"
-#define SHADER_TECHNIQUE_RenderBall_CabMode "RenderBall_CabMode"
-#define SHADER_TECHNIQUE_RenderBall_CabMode_DecalMode "RenderBall_CabMode_DecalMode"
-#define SHADER_TECHNIQUE_RenderBallTrail "RenderBallTrail"
-
-#define SHADER_TECHNIQUE_basic_without_texture "basic_without_texture"
-#define SHADER_TECHNIQUE_basic_with_texture "basic_with_texture"
-#define SHADER_TECHNIQUE_basic_depth_only_without_texture "basic_depth_only_without_texture"
-#define SHADER_TECHNIQUE_basic_depth_only_with_texture "basic_depth_only_with_texture"
-#define SHADER_TECHNIQUE_bg_decal_without_texture "bg_decal_without_texture"
-#define SHADER_TECHNIQUE_bg_decal_with_texture "bg_decal_with_texture"
-#define SHADER_TECHNIQUE_kickerBoolean "kickerBoolean"
-#define SHADER_TECHNIQUE_light_with_texture "light_with_texture"
-#define SHADER_TECHNIQUE_light_without_texture "light_without_texture"
-
-#define SHADER_TECHNIQUE_basic_DMD "basic_DMD"
-#define SHADER_TECHNIQUE_basic_DMD_ext "basic_DMD_ext"
-#define SHADER_TECHNIQUE_basic_DMD_world "basic_DMD_world"
-#define SHADER_TECHNIQUE_basic_DMD_world_ext "basic_DMD_world_ext"
-#define SHADER_TECHNIQUE_basic_noDMD "basic_noDMD"
-#define SHADER_TECHNIQUE_basic_noDMD_world "basic_noDMD_world"
-#define SHADER_TECHNIQUE_basic_noDMD_notex "basic_noDMD_notex"
-
-#define SHADER_TECHNIQUE_AO "AO"
-#define SHADER_TECHNIQUE_NFAA "NFAA"
-#define SHADER_TECHNIQUE_DLAA_edge "DLAA_edge"
-#define SHADER_TECHNIQUE_DLAA "DLAA"
-#define SHADER_TECHNIQUE_FXAA1 "FXAA1"
-#define SHADER_TECHNIQUE_FXAA2 "FXAA2"
-#define SHADER_TECHNIQUE_FXAA3 "FXAA3"
-#define SHADER_TECHNIQUE_fb_tonemap "fb_tonemap"
-#define SHADER_TECHNIQUE_fb_bloom "fb_bloom"
-#define SHADER_TECHNIQUE_fb_AO "fb_AO"
-#define SHADER_TECHNIQUE_fb_tonemap_AO "fb_tonemap_AO"
-#define SHADER_TECHNIQUE_fb_tonemap_AO_static "fb_tonemap_AO_static"
-#define SHADER_TECHNIQUE_fb_tonemap_no_filterRGB "fb_tonemap_no_filterRGB"
-#define SHADER_TECHNIQUE_fb_tonemap_no_filterRG "fb_tonemap_no_filterRG"
-#define SHADER_TECHNIQUE_fb_tonemap_no_filterR "fb_tonemap_no_filterR"
-#define SHADER_TECHNIQUE_fb_tonemap_AO_no_filter "fb_tonemap_AO_no_filter"
-#define SHADER_TECHNIQUE_fb_tonemap_AO_no_filter_static "fb_tonemap_AO_no_filter_static"
-#define SHADER_TECHNIQUE_fb_bloom_horiz9x9 "fb_bloom_horiz9x9"
-#define SHADER_TECHNIQUE_fb_bloom_vert9x9 "fb_bloom_vert9x9"
-#define SHADER_TECHNIQUE_fb_bloom_horiz19x19 "fb_bloom_horiz19x19"
-#define SHADER_TECHNIQUE_fb_bloom_vert19x19 "fb_bloom_vert19x19"
-#define SHADER_TECHNIQUE_fb_bloom_horiz19x19h "fb_bloom_horiz19x19h"
-#define SHADER_TECHNIQUE_fb_bloom_vert19x19h "fb_bloom_vert19x19h"
-#define SHADER_TECHNIQUE_SSReflection "SSReflection"
-#define SHADER_TECHNIQUE_fb_mirror "fb_mirror"
-
-#define SHADER_TECHNIQUE_basic_noLight "basic_noLight"
-
-#define SHADER_TECHNIQUE_bulb_light "bulb_light"
-
-#define SHADER_TECHNIQUE_SMAA_ColorEdgeDetection "SMAA_ColorEdgeDetection"
-#define SHADER_TECHNIQUE_SMAA_BlendWeightCalculation "SMAA_BlendWeightCalculation"
-#define SHADER_TECHNIQUE_SMAA_NeighborhoodBlending "SMAA_NeighborhoodBlending"
-
-#define SHADER_TECHNIQUE_stereo_TB "stereo_TB"
-#define SHADER_TECHNIQUE_stereo_SBS "stereo_SBS"
-#define SHADER_TECHNIQUE_stereo_Int "stereo_Int"
-#define SHADER_TECHNIQUE_stereo_AMD_DEBUG "stereo_AMD_DEBUG"
-
-#ifdef ENABLE_SDL
-typedef char* SHADER_UNIFORM_HANDLE;
-typedef char* SHADER_TECHNIQUE_HANDLE;
-typedef void ID3DXEffect;
-#endif
-#endif
-
-#ifndef ENABLE_SDL
-typedef D3DXHANDLE SHADER_UNIFORM_HANDLE;
-typedef D3DXHANDLE SHADER_TECHNIQUE_HANDLE;
 #endif
 
 class Shader final
@@ -221,9 +177,9 @@ public:
    void Begin(const unsigned int pass);
    void End();
 
-   void SetTexture(const SHADER_UNIFORM_HANDLE texelName, Texture *texel, const TextureFilter filter, const bool clampU, const bool clampV, const bool force_linear_rgb);
-   void SetTexture(const SHADER_UNIFORM_HANDLE texelName, Sampler* texel);
-   void SetTextureNull(const SHADER_UNIFORM_HANDLE texelName);
+   void SetTexture(const ShaderUniforms texelName, Texture* texel, const TextureFilter filter, const bool clampU, const bool clampV, const bool force_linear_rgb);
+   void SetTexture(const ShaderUniforms texelName, Sampler* texel);
+   void SetTextureNull(const ShaderUniforms texelName);
    void SetMaterial(const Material * const mat);
 
    void SetDisableLighting(const float value); // only set top
@@ -237,17 +193,17 @@ public:
    void SetLightData(const vec4& color);
    void SetLightImageBackglassMode(const bool imageMode, const bool backglassMode);
 
-   void SetTechnique(const SHADER_TECHNIQUE_HANDLE technique);
-   void SetTechniqueMetal(const SHADER_TECHNIQUE_HANDLE technique, const bool isMetal);
+   void SetTechnique(const ShaderTechniques technique);
+   void SetTechniqueMetal(const ShaderTechniques technique, const bool isMetal);
 
-   void SetMatrix(const SHADER_UNIFORM_HANDLE hParameter, const Matrix3D* pMatrix);
-   void SetUniformBlock(const SHADER_UNIFORM_HANDLE hParameter, const float* pMatrix, const size_t size);
-   void SetVector(const SHADER_UNIFORM_HANDLE hParameter, const vec4* pVector);
-   void SetVector(const SHADER_UNIFORM_HANDLE hParameter, const float x, const float y, const float z, const float w);
-   void SetFloat(const SHADER_UNIFORM_HANDLE hParameter, const float f);
-   void SetInt(const SHADER_UNIFORM_HANDLE hParameter, const int i);
-   void SetBool(const SHADER_UNIFORM_HANDLE hParameter, const bool b);
-   void SetFloatArray(const SHADER_UNIFORM_HANDLE hParameter, const float* pData, const unsigned int count);
+   void SetMatrix(const ShaderUniforms hParameter, const Matrix3D* pMatrix);
+   void SetUniformBlock(const ShaderUniforms hParameter, const float* pMatrix, const size_t size);
+   void SetVector(const ShaderUniforms hParameter, const vec4* pVector);
+   void SetVector(const ShaderUniforms hParameter, const float x, const float y, const float z, const float w);
+   void SetFloat(const ShaderUniforms hParameter, const float f);
+   void SetInt(const ShaderUniforms hParameter, const int i);
+   void SetBool(const ShaderUniforms hParameter, const bool b);
+   void SetFloatArray(const ShaderUniforms hParameter, const float* pData, const unsigned int count);
 
    static void SetTransform(const TransformStateType p1, const Matrix3D* p2, const int count);
    static void GetTransform(const TransformStateType p1, Matrix3D* p2, const int count);
@@ -281,88 +237,77 @@ private:
 #ifdef ENABLE_SDL
    string m_shaderCodeName;
    Texture* m_nullTexture;
+   struct attributeLoc
+   {
+      GLenum type;
+      int location;
+      int size;
+   };
+   struct uniformLoc
+   {
+      GLenum type;
+      int location;
+      int size;
+      GLuint blockBuffer;
+   };
+   struct ShaderTechnique
+   {
+      int index;
+      string& name;
+#ifdef ENABLE_SDL
+      int program;
+      attributeLoc attributeLocation[SHADER_ATTRIBUTE_COUNT];
+      uniformLoc uniformLocation[SHADER_UNIFORM_COUNT];
+#endif
+   };
+   struct floatP
+   {
+      size_t len;
+      float* data;
+   };
 
 #if DEBUG_LEVEL_LOG > 0
    void LOG(const int level, const string& fileNameRoot, const string& message);
 #endif
    bool parseFile(const string& fileNameRoot, const string& fileName, int level, robin_hood::unordered_map<string, string>& values, const string& parentMode);
    string analyzeFunction(const char* shaderCodeName, const string& technique, const string& functionName, const robin_hood::unordered_map<string, string>& values);
-   bool compileGLShader(const string& fileNameRoot, const string& shaderCodeName, const string& vertex, const string& geometry, const string& fragment);
+   ShaderTechnique* compileGLShader(const string& fileNameRoot, string& shaderCodeName, const string& vertex, const string& geometry, const string& fragment);
 
-   struct attributeLoc {
-      GLenum type;
-      int location;
-      int size;
-   };
-   struct uniformLoc {
-      GLenum type;
-      int location;
-      int size;
-      GLuint blockBuffer;
-   };
-   struct floatP {
-      size_t len;
-      float* data;
-   };
-
-#ifdef TWEAK_GL_SHADER
-   struct glShader {
-      int program;
-      attributeLoc attributeLocation[SHADER_ATTRIBUTE_COUNT];
-      uniformLoc uniformLocation[SHADER_UNIFORM_COUNT];
-   };
-   glShader shaderList[SHADER_TECHNIQUE_COUNT];
    float uniformFloat[SHADER_UNIFORM_COUNT];
    floatP uniformFloatP[SHADER_UNIFORM_COUNT];
    int uniformInt[SHADER_UNIFORM_COUNT];
    int uniformTex[SHADER_UNIFORM_COUNT];
-   shaderTechniques technique;
-#ifndef _DEBUG
- #define staticS static
-#else
- #define staticS
-#endif
-   staticS shaderUniforms getUniformByName(const string& name);
-   staticS shaderAttributes getAttributeByName(const string& name);
-   staticS shaderTechniques getTechniqueByName(const string& name);
-
-#else
-
-   struct glShader {
-      int program;
-      std::map<string, attributeLoc> *attributeLocation; //!! all unordered maps?
-      std::map<string, uniformLoc> *uniformLocation;
+   
+   struct ShaderUniform
+   {
+      string name;
+      int tex_unit;
    };
-   std::map<string, glShader> shaderList;
-   std::map<string, float> uniformFloat;
-   std::map<string, floatP> uniformFloatP;
-   std::map<string, int> uniformInt;
-   std::map<string, int> uniformTex;
-   char technique[256];
-#endif
+
+   ShaderTechnique* m_techniques[SHADER_TECHNIQUE_COUNT];
+   ShaderTechnique* m_technique;
+   static int m_currentShaderProgram;
+   static const string Shader::shaderTechniqueNames[SHADER_TECHNIQUE_COUNT];
+   static const ShaderUniform Shader::shaderUniformNames[SHADER_UNIFORM_COUNT];
+
+   ShaderUniforms getUniformByName(const string& name);
+   shaderAttributes getAttributeByName(const string& name);
 
    static Matrix3D mWorld, mView, mProj[2];
-   static int lastShaderProgram;
    static Sampler* noTexture;
    static Sampler* noTextureMSAA;
    static const float* zeroData;
    static int nextTextureSlot;
    static int* textureSlotList;
-   //static std::map<int, int> slotTextureList;
    static int maxSlots;
-
-   glShader* m_currentTechnique;
 
 public:
    void setAttributeFormat(const DWORD fvf);
 
-   static void setTextureDirty(const int TextureID);
    static string shaderPath;
    static string Defines;
 
 #else
-
    ID3DXEffect * m_shader;
-
 #endif
 };

--- a/ShaderDX9.cpp
+++ b/ShaderDX9.cpp
@@ -81,7 +81,7 @@ void Shader::End()
    CHECKD3D(m_shader->End());
 }
 
-void Shader::SetTexture(const SHADER_UNIFORM_HANDLE texelName, Texture *texel, const bool clampU, const bool clampV, const bool force_linear_rgb)
+void Shader::SetTexture(const ShaderUniforms texelName, Texture *texel, const bool clampU, const bool clampV, const bool force_linear_rgb)
 {
    const unsigned int idx = texelName[strlen(texelName) - 1] - '0'; // current convention: SetTexture gets "TextureX", where X 0..4
    const bool cache = idx < TEXTURESET_STATE_CACHE_SIZE;
@@ -107,7 +107,7 @@ void Shader::SetTexture(const SHADER_UNIFORM_HANDLE texelName, Texture *texel, c
    }
 }
 
-void Shader::SetTexture(const SHADER_UNIFORM_HANDLE texelName, D3DTexture *texel)
+void Shader::SetTexture(const ShaderUniforms texelName, D3DTexture *texel)
 {
    const unsigned int idx = texelName[strlen(texelName) - 1] - '0'; // current convention: SetTexture gets "TextureX", where X 0..4
    if (idx < TEXTURESET_STATE_CACHE_SIZE)
@@ -118,7 +118,7 @@ void Shader::SetTexture(const SHADER_UNIFORM_HANDLE texelName, D3DTexture *texel
    m_renderDevice->m_curTextureChanges++;
 }
 
-void Shader::SetTextureNull(const SHADER_UNIFORM_HANDLE texelName)
+void Shader::SetTextureNull(const ShaderUniforms texelName)
 {
    const unsigned int idx = texelName[strlen(texelName) - 1] - '0'; // current convention: SetTexture gets "TextureX", where X 0..4
    const bool cache = idx < TEXTURESET_STATE_CACHE_SIZE;
@@ -131,7 +131,7 @@ void Shader::SetTextureNull(const SHADER_UNIFORM_HANDLE texelName)
    m_renderDevice->m_curTextureChanges++;
 }
 
-void Shader::SetTechnique(const SHADER_TECHNIQUE_HANDLE _technique)
+void Shader::SetTechnique(const ShaderTechniques _technique)
 {
    if (strcmp(currentTechnique, _technique) /*|| (m_renderDevice->m_curShader != this)*/)
    {
@@ -142,43 +142,43 @@ void Shader::SetTechnique(const SHADER_TECHNIQUE_HANDLE _technique)
    }
 }
 
-void Shader::SetMatrix(const SHADER_UNIFORM_HANDLE hParameter, const Matrix3D* pMatrix)
+void Shader::SetMatrix(const ShaderUniforms hParameter, const Matrix3D* pMatrix)
 {
    /*CHECKD3D(*/m_shader->SetMatrix(hParameter, (const D3DXMATRIX*)pMatrix)/*)*/; // leads to invalid calls when setting some of the matrices (as hlsl compiler optimizes some down to less than 4x4)
    m_renderDevice->m_curParameterChanges++;
 }
 
-void Shader::SetVector(const SHADER_UNIFORM_HANDLE hParameter, const vec4* pVector)
+void Shader::SetVector(const ShaderUniforms hParameter, const vec4* pVector)
 {
    CHECKD3D(m_shader->SetVector(hParameter, pVector));
    m_renderDevice->m_curParameterChanges++;
 }
 
-void Shader::SetVector(const SHADER_UNIFORM_HANDLE hParameter, const float x, const float y, const float z, const float w)
+void Shader::SetVector(const ShaderUniforms hParameter, const float x, const float y, const float z, const float w)
 {
    vec4 pVector = vec4(x, y, z, w);
    CHECKD3D(m_shader->SetVector(hParameter, &pVector));
 }
 
-void Shader::SetFloat(const SHADER_UNIFORM_HANDLE hParameter, const float f)
+void Shader::SetFloat(const ShaderUniforms hParameter, const float f)
 {
    CHECKD3D(m_shader->SetFloat(hParameter, f));
    m_renderDevice->m_curParameterChanges++;
 }
 
-void Shader::SetInt(const SHADER_UNIFORM_HANDLE hParameter, const int i)
+void Shader::SetInt(const ShaderUniforms hParameter, const int i)
 {
    CHECKD3D(m_shader->SetInt(hParameter, i));
    m_renderDevice->m_curParameterChanges++;
 }
 
-void Shader::SetBool(const SHADER_UNIFORM_HANDLE hParameter, const bool b)
+void Shader::SetBool(const ShaderUniforms hParameter, const bool b)
 {
    CHECKD3D(m_shader->SetBool(hParameter, b));
    m_renderDevice->m_curParameterChanges++;
 }
 
-void Shader::SetFloatArray(const SHADER_UNIFORM_HANDLE hParameter, const float* pData, const unsigned int count)
+void Shader::SetFloatArray(const ShaderUniforms hParameter, const float* pData, const unsigned int count)
 {
    CHECKD3D(m_shader->SetValue(hParameter, pData, count*sizeof(float)));
    m_renderDevice->m_curParameterChanges++;

--- a/ShaderGL.cpp
+++ b/ShaderGL.cpp
@@ -327,7 +327,16 @@ Shader::ShaderTechnique* Shader::compileGLShader(const string& fileNameRoot, str
                }
             }
             auto uniformIndex = getUniformByName(uniformName);
-            if (uniformIndex < SHADER_UNIFORM_COUNT) shader->uniformLocation[uniformIndex] = newLoc;
+            if (uniformIndex < SHADER_UNIFORM_COUNT)
+            {
+               shader->uniformLocation[uniformIndex] = newLoc;
+               if (shaderUniformNames[uniformIndex].default_tex_unit != -1)
+               { 
+                  // Unlike DirectX, OpenGL won't return 0 if the texture is not bound to a black texture
+                  // This will cause error for static pre-render which, done before bulb light transmission is evaluated and bound
+                  SetTextureNull(uniformIndex); 
+               }
+            }
          }
       }
 

--- a/ShaderGL.cpp
+++ b/ShaderGL.cpp
@@ -329,9 +329,12 @@ bool Shader::compileGLShader(const string& fileNameRoot, const string& shaderCod
       shaderCode << fragment;
       shaderCode.close();
    }
-   glDeleteShader(vertexShader);
-   glDeleteShader(geometryShader);
-   glDeleteShader(fragmentShader);
+   if (vertexShader)
+      glDeleteShader(vertexShader);
+   if (geometryShader)
+      glDeleteShader(geometryShader);
+   if (fragmentShader)
+      glDeleteShader(fragmentShader);
    delete [] fragmentSource;
    delete [] geometrySource;
    delete [] vertexSource;
@@ -594,6 +597,14 @@ void Shader::Unload()
    for (int i = 0; i < SHADER_UNIFORM_COUNT; ++i)
       if(uniformFloatP[i].data)
          free(uniformFloatP[i].data);
+   for (int i = 0; i < SHADER_TECHNIQUE_COUNT; i++)
+   {
+      if (shaderList[i].program > 0)
+      {
+         glDeleteProgram(shaderList[i].program);
+         shaderList[i].program = -1;
+      }
+   }
 #else
    //Free all uniform cache pointers
    if (uniformFloatP.size() > 0)

--- a/ShaderGL.cpp
+++ b/ShaderGL.cpp
@@ -596,7 +596,7 @@ void Shader::Begin()
    m_nextTextureSlot = 5; // Slots 0 to 4 are used by static texture unit allocation
    m_currentShaderProgram = m_technique->program;
    for (int uniformName = 0; uniformName < SHADER_UNIFORM_COUNT; ++uniformName)
-      ApplyUniform((ShaderUniforms) uniformName);
+      ApplyUniform((ShaderUniforms)uniformName);
 }
 
 void Shader::End()
@@ -963,7 +963,7 @@ void Shader::ApplyUniform(const ShaderUniforms uniformName)
             texel = noTexture;
          }
       }
-      int tex_unit = shaderUniformNames[uniformName].tex_unit;
+      int tex_unit = shaderUniformNames[uniformName].default_tex_unit;
       if (tex_unit == -1)
       {
          // Texture units are preaffected to avoid collision (copied from DX9 implementation) but somes are not.

--- a/ShaderGL.cpp
+++ b/ShaderGL.cpp
@@ -580,7 +580,7 @@ void Shader::setAttributeFormat(DWORD fvf)
    }
 }
 
-void Shader::Begin(const unsigned int pass)
+void Shader::Begin()
 {
    m_currentShader = this;
    if (m_technique == nullptr)

--- a/backGlass.cpp
+++ b/backGlass.cpp
@@ -262,7 +262,7 @@ void BackGlass::Render()
       -1.0f, -1.0f, 0.0f, 0.0f, 1.0f
    };
 
-   m_pd3dDevice->DMDShader->Begin(0);
+   m_pd3dDevice->DMDShader->Begin();
    m_pd3dDevice->DrawTexturedQuad((Vertex3D_TexelOnly*)Verts);
    m_pd3dDevice->DMDShader->End();
 
@@ -333,7 +333,7 @@ void BackGlass::DMDdraw(float DMDposx, float DMDposy, float DMDwidth, float DMDh
          DMDVerts[i * 5 + 1] = 1.0f - (DMDVerts[i * 5 + 1] * DMDheight + DMDposy)*2.0f;
       }
 
-      m_pd3dDevice->DMDShader->Begin(0);
+      m_pd3dDevice->DMDShader->Begin();
       m_pd3dDevice->DrawTexturedQuad((Vertex3D_TexelOnly*)DMDVerts);
       m_pd3dDevice->DMDShader->End();
 

--- a/backGlass.cpp
+++ b/backGlass.cpp
@@ -239,9 +239,9 @@ void BackGlass::Render()
    }
 
    if (m_backgroundTexture)
-      m_pd3dDevice->DMDShader->SetTexture(SHADER_Texture0, m_backgroundTexture);
+      m_pd3dDevice->DMDShader->SetTexture(SHADER_tex_sprite, m_backgroundTexture);
    else if (m_backgroundFallback)
-      m_pd3dDevice->DMDShader->SetTexture(SHADER_Texture0, m_backgroundFallback, TextureFilter::TEXTURE_MODE_TRILINEAR, true, true, false);
+      m_pd3dDevice->DMDShader->SetTexture(SHADER_tex_sprite, m_backgroundFallback, TextureFilter::TEXTURE_MODE_TRILINEAR, true, true, false);
    else return;
 
    m_pd3dDevice->SetRenderState(RenderDevice::ZWRITEENABLE, RenderDevice::RS_FALSE);
@@ -292,7 +292,7 @@ void BackGlass::DMDdraw(float DMDposx, float DMDposy, float DMDwidth, float DMDh
          m_pd3dDevice->DMDShader->SetTechnique(SHADER_TECHNIQUE_basic_DMD_ext);
 
       if (g_pplayer->m_texdmd != nullptr)
-         m_pd3dDevice->DMDShader->SetTexture(SHADER_Texture0, m_pd3dDevice->m_texMan.LoadTexture(g_pplayer->m_texdmd, TextureFilter::TEXTURE_MODE_NONE, true, true, false));
+         m_pd3dDevice->DMDShader->SetTexture(SHADER_tex_dmd, m_pd3dDevice->m_texMan.LoadTexture(g_pplayer->m_texdmd, TextureFilter::TEXTURE_MODE_NONE, true, true, false));
       //      m_pd3dPrimaryDevice->DMDShader->SetVector(SHADER_quadOffsetScale, 0.0f, -1.0f, backglass_scale, backglass_scale*(float)backglass_height / (float)backglass_width);
       bool zDisabled = false;
       m_pd3dDevice->SetRenderStateCulling(RenderDevice::CULL_NONE);

--- a/bumper.cpp
+++ b/bumper.cpp
@@ -301,7 +301,7 @@ void Bumper::RenderBase(const Material * const baseMaterial)
    g_pplayer->m_pin3d.EnableAlphaBlend(false);
    pd3dDevice->basicShader->SetAlphaTestValue((float)(1.0 / 255.0));
 
-   pd3dDevice->basicShader->Begin(0);
+   pd3dDevice->basicShader->Begin();
    pd3dDevice->DrawIndexedPrimitiveVB(RenderDevice::TRIANGLELIST, MY_D3DFVF_NOTEX2_VERTEX, m_baseVertexBuffer, 0, bumperBaseNumVertices, m_baseIndexBuffer, 0, bumperBaseNumIndices);
    pd3dDevice->basicShader->End();
 }
@@ -315,7 +315,7 @@ void Bumper::RenderSocket(const Material * const socketMaterial)
    g_pplayer->m_pin3d.EnableAlphaBlend(false);
    pd3dDevice->basicShader->SetAlphaTestValue((float)(1.0 / 255.0));
 
-   pd3dDevice->basicShader->Begin(0);
+   pd3dDevice->basicShader->Begin();
    pd3dDevice->DrawIndexedPrimitiveVB(RenderDevice::TRIANGLELIST, MY_D3DFVF_NOTEX2_VERTEX, m_socketVertexBuffer, 0, bumperSocketNumVertices, m_socketIndexBuffer, 0, bumperSocketNumIndices);
    pd3dDevice->basicShader->End();
 }
@@ -329,7 +329,7 @@ void Bumper::RenderCap(const Material * const capMaterial)
    g_pplayer->m_pin3d.EnableAlphaBlend(false);
    pd3dDevice->basicShader->SetAlphaTestValue((float)(1.0 / 255.0));
 
-   pd3dDevice->basicShader->Begin(0);
+   pd3dDevice->basicShader->Begin();
    pd3dDevice->DrawIndexedPrimitiveVB(RenderDevice::TRIANGLELIST, MY_D3DFVF_NOTEX2_VERTEX, m_capVertexBuffer, 0, bumperCapNumVertices, m_capIndexBuffer, 0, bumperCapNumIndices);
    pd3dDevice->basicShader->End();
 }
@@ -467,7 +467,7 @@ void Bumper::RenderDynamic()
       pd3dDevice->basicShader->SetAlphaTestValue(-1.0f);
 
       // render ring
-      pd3dDevice->basicShader->Begin(0);
+      pd3dDevice->basicShader->Begin();
       pd3dDevice->DrawIndexedPrimitiveVB(RenderDevice::TRIANGLELIST, MY_D3DFVF_NOTEX2_VERTEX, m_ringVertexBuffer, 0, bumperRingNumVertices, m_ringIndexBuffer, 0, bumperRingNumIndices);
       pd3dDevice->basicShader->End();
    }

--- a/bumper.cpp
+++ b/bumper.cpp
@@ -297,7 +297,7 @@ void Bumper::RenderBase(const Material * const baseMaterial)
    RenderDevice * const pd3dDevice = g_pplayer->m_pin3d.m_pd3dPrimaryDevice;
 
    pd3dDevice->basicShader->SetMaterial(baseMaterial);
-   pd3dDevice->basicShader->SetTexture(SHADER_Texture0, &m_baseTexture, TextureFilter::TEXTURE_MODE_TRILINEAR, false, false, false);
+   pd3dDevice->basicShader->SetTexture(SHADER_tex_base_color, &m_baseTexture, TextureFilter::TEXTURE_MODE_TRILINEAR, false, false, false);
    g_pplayer->m_pin3d.EnableAlphaBlend(false);
    pd3dDevice->basicShader->SetAlphaTestValue((float)(1.0 / 255.0));
 
@@ -311,7 +311,7 @@ void Bumper::RenderSocket(const Material * const socketMaterial)
    RenderDevice * const pd3dDevice = g_pplayer->m_pin3d.m_pd3dPrimaryDevice;
 
    pd3dDevice->basicShader->SetMaterial(socketMaterial);
-   pd3dDevice->basicShader->SetTexture(SHADER_Texture0, &m_skirtTexture, TextureFilter::TEXTURE_MODE_TRILINEAR, false, false, false);
+   pd3dDevice->basicShader->SetTexture(SHADER_tex_base_color, &m_skirtTexture, TextureFilter::TEXTURE_MODE_TRILINEAR, false, false, false);
    g_pplayer->m_pin3d.EnableAlphaBlend(false);
    pd3dDevice->basicShader->SetAlphaTestValue((float)(1.0 / 255.0));
 
@@ -325,7 +325,7 @@ void Bumper::RenderCap(const Material * const capMaterial)
    RenderDevice * const pd3dDevice = g_pplayer->m_pin3d.m_pd3dPrimaryDevice;
 
    pd3dDevice->basicShader->SetMaterial(capMaterial);
-   pd3dDevice->basicShader->SetTexture(SHADER_Texture0, &m_capTexture, TextureFilter::TEXTURE_MODE_TRILINEAR, false, false, false);
+   pd3dDevice->basicShader->SetTexture(SHADER_tex_base_color, &m_capTexture, TextureFilter::TEXTURE_MODE_TRILINEAR, false, false, false);
    g_pplayer->m_pin3d.EnableAlphaBlend(false);
    pd3dDevice->basicShader->SetAlphaTestValue((float)(1.0 / 255.0));
 
@@ -462,7 +462,7 @@ void Bumper::RenderDynamic()
       }
 
       pd3dDevice->basicShader->SetTechniqueMetal(SHADER_TECHNIQUE_basic_with_texture, ringMaterial.m_bIsMetal);
-      pd3dDevice->basicShader->SetTexture(SHADER_Texture0, &m_ringTexture, TextureFilter::TEXTURE_MODE_TRILINEAR, false, false, false);
+      pd3dDevice->basicShader->SetTexture(SHADER_tex_base_color, &m_ringTexture, TextureFilter::TEXTURE_MODE_TRILINEAR, false, false, false);
       pd3dDevice->basicShader->SetMaterial(&ringMaterial);
       pd3dDevice->basicShader->SetAlphaTestValue(-1.0f);
 
@@ -499,7 +499,7 @@ void Bumper::RenderDynamic()
       }
 
       const Material * const mat = m_ptable->GetMaterial(m_d.m_szSkirtMaterial);
-      pd3dDevice->basicShader->SetTexture(SHADER_Texture0, &m_skirtTexture, TextureFilter::TEXTURE_MODE_TRILINEAR, false, false, false);
+      pd3dDevice->basicShader->SetTexture(SHADER_tex_base_color, &m_skirtTexture, TextureFilter::TEXTURE_MODE_TRILINEAR, false, false, false);
       pd3dDevice->basicShader->SetTechniqueMetal(SHADER_TECHNIQUE_basic_with_texture, mat->m_bIsMetal);
       pd3dDevice->SetRenderStateCulling(RenderDevice::CULL_NONE);
       RenderSocket(mat);

--- a/decal.cpp
+++ b/decal.cpp
@@ -584,7 +584,7 @@ void Decal::RenderObject()
       pd3dDevice->basicShader->SetVector(SHADER_cBase_Alpha, &staticColor);
    }
 
-   pd3dDevice->basicShader->Begin(0);
+   pd3dDevice->basicShader->Begin();
    pd3dDevice->DrawPrimitiveVB(RenderDevice::TRIANGLEFAN, m_backglass ? MY_D3DTRANSFORMED_NOTEX2_VERTEX : MY_D3DFVF_NOTEX2_VERTEX, m_vertexBuffer, 0, 4, true);
    pd3dDevice->basicShader->End();
 

--- a/decal.cpp
+++ b/decal.cpp
@@ -541,7 +541,7 @@ void Decal::RenderObject()
          pd3dDevice->basicShader->SetTechniqueMetal(SHADER_TECHNIQUE_basic_with_texture, mat->m_bIsMetal);
       else
          pd3dDevice->basicShader->SetTechnique(SHADER_TECHNIQUE_bg_decal_with_texture);
-      pd3dDevice->basicShader->SetTexture(SHADER_Texture0, pd3dDevice->m_texMan.LoadTexture(m_textImg, TextureFilter::TEXTURE_MODE_TRILINEAR, false, false, false));
+      pd3dDevice->basicShader->SetTexture(SHADER_tex_base_color, pd3dDevice->m_texMan.LoadTexture(m_textImg, TextureFilter::TEXTURE_MODE_TRILINEAR, false, false, false));
       pd3dDevice->basicShader->SetAlphaTestValue(-1.0f);
    }
    else
@@ -553,7 +553,7 @@ void Decal::RenderObject()
             pd3dDevice->basicShader->SetTechniqueMetal(SHADER_TECHNIQUE_basic_with_texture, mat->m_bIsMetal);
          else
             pd3dDevice->basicShader->SetTechnique(SHADER_TECHNIQUE_bg_decal_with_texture);
-         pd3dDevice->basicShader->SetTexture(SHADER_Texture0, pin, TextureFilter::TEXTURE_MODE_TRILINEAR, false, false, false);
+         pd3dDevice->basicShader->SetTexture(SHADER_tex_base_color, pin, TextureFilter::TEXTURE_MODE_TRILINEAR, false, false, false);
          pd3dDevice->basicShader->SetAlphaTestValue(pin->m_alphaTestValue * (float)(1.0 / 255.0));
       }
       else

--- a/dialogs/PhysicsOptionsDialog.cpp
+++ b/dialogs/PhysicsOptionsDialog.cpp
@@ -41,7 +41,7 @@ BOOL PhysicsOptionsDialog::OnInitDialog()
         char tmp[256];
         sprintf_s(tmp, sizeof(tmp), "PhysicsSetName%u", i);
         if (LoadValue(regKey[RegName::Player], tmp, physicsoptions[i], 256) != S_OK)
-            sprintf_s(physicsoptions[i], sizeof(physicsoptions[i]), "Set %u", i + 1);
+            sprintf_s(physicsoptions[i], 256, "Set %u", i + 1);
         sprintf_s(tmp, sizeof(tmp), "%u: %s", i + 1, physicsoptions[i]);
         const size_t index = SendMessage(hwndList, LB_ADDSTRING, 0, (size_t)tmp);
         int * const sd = new int;

--- a/dialogs/VideoOptionsDialog.cpp
+++ b/dialogs/VideoOptionsDialog.cpp
@@ -128,8 +128,8 @@ void VideoOptionsDialog::ResetVideoPreferences(const unsigned int profile) // 0 
    constexpr float stereo3DContrast = 1.0f;
    sprintf_s(tmp, sizeof(tmp), "%f", stereo3DContrast);
    SetDlgItemText(IDC_3D_STEREO_CONTRAST, tmp);
-   constexpr float stereo3DDeSaturation = 0.0f;
-   sprintf_s(tmp, sizeof(tmp), "%f", stereo3DDeSaturation);
+   constexpr float stereo3DDesaturation = 0.0f;
+   sprintf_s(tmp, sizeof(tmp), "%f", stereo3DDesaturation);
    SetDlgItemText(IDC_3D_STEREO_DESATURATION, tmp);
    SendMessage(GetDlgItem(IDC_USE_NVIDIA_API_CHECK).GetHwnd(), BM_SETCHECK, false ? BST_CHECKED : BST_UNCHECKED, 0);
    }

--- a/dispreel.cpp
+++ b/dispreel.cpp
@@ -239,7 +239,7 @@ void DispReel::RenderDynamic()
 
    pd3dDevice->DMDShader->SetTexture(SHADER_Texture0, pin, TextureFilter::TEXTURE_MODE_TRILINEAR, false, false, false);
 
-   pd3dDevice->DMDShader->Begin(0);
+   pd3dDevice->DMDShader->Begin();
 
    // set up all the reel positions within the object frame
    const float renderspacingx = max(0.0f, m_d.m_reelspacing / (float)EDITOR_BG_WIDTH);

--- a/dispreel.cpp
+++ b/dispreel.cpp
@@ -237,7 +237,7 @@ void DispReel::RenderDynamic()
    const vec4 c = convertColor(0xFFFFFFFF, 1.f);
    pd3dDevice->DMDShader->SetVector(SHADER_vColor_Intensity, &c);
 
-   pd3dDevice->DMDShader->SetTexture(SHADER_Texture0, pin, TextureFilter::TEXTURE_MODE_TRILINEAR, false, false, false);
+   pd3dDevice->DMDShader->SetTexture(SHADER_tex_sprite, pin, TextureFilter::TEXTURE_MODE_TRILINEAR, false, false, false);
 
    pd3dDevice->DMDShader->Begin();
 

--- a/flasher.cpp
+++ b/flasher.cpp
@@ -992,7 +992,7 @@ void Flasher::ResetVideoCap()
     m_isVideoCap = false;
     if (m_videoCapTex)
     {
-      //  g_pplayer->m_pin3d.m_pd3dPrimaryDevice->flasherShader->SetTextureNull(SHADER_Texture0); //!! ??
+      //  g_pplayer->m_pin3d.m_pd3dPrimaryDevice->flasherShader->SetTextureNull(SHADER_tex_flasher_A); //!! ??
         g_pplayer->m_pin3d.m_pd3dPrimaryDevice->m_texMan.UnloadTexture(m_videoCapTex);
         delete m_videoCapTex;
         m_videoCapTex = nullptr;
@@ -1214,7 +1214,7 @@ void Flasher::RenderDynamic()
           pd3dDevice->DMDShader->SetTechnique(SHADER_TECHNIQUE_basic_DMD_world_ext);
 
        if (g_pplayer->m_texdmd != nullptr)
-          pd3dDevice->DMDShader->SetTexture(SHADER_Texture0, g_pplayer->m_pin3d.m_pd3dPrimaryDevice->m_texMan.LoadTexture(g_pplayer->m_texdmd, TextureFilter::TEXTURE_MODE_NONE, true, true, false));
+          pd3dDevice->DMDShader->SetTexture(SHADER_tex_dmd, g_pplayer->m_pin3d.m_pd3dPrimaryDevice->m_texMan.LoadTexture(g_pplayer->m_texdmd, TextureFilter::TEXTURE_MODE_NONE, true, true, false));
 
        pd3dDevice->DMDShader->Begin();
        pd3dDevice->DrawIndexedPrimitiveVB(RenderDevice::TRIANGLELIST, MY_D3DFVF_TEX, m_dynamicVertexBuffer, 0, m_numVertices, m_dynamicIndexBuffer, 0, m_numPolys * 3);
@@ -1243,7 +1243,7 @@ void Flasher::RenderDynamic()
        if (pinA && !pinB)
        {
           flasherMode = 0.f;
-          pd3dDevice->flasherShader->SetTexture(SHADER_Texture0, pinA, TextureFilter::TEXTURE_MODE_TRILINEAR, true, true, false);
+          pd3dDevice->flasherShader->SetTexture(SHADER_tex_flasher_A, pinA, TextureFilter::TEXTURE_MODE_TRILINEAR, true, true, false);
 
           if (!m_d.m_addBlend)
              flasherData.x = pinA->m_alphaTestValue * (float)(1.0/255.0);
@@ -1253,7 +1253,7 @@ void Flasher::RenderDynamic()
        else if (!pinA && pinB)
        {
           flasherMode = 0.f;
-          pd3dDevice->flasherShader->SetTexture(SHADER_Texture0, pinB, TextureFilter::TEXTURE_MODE_TRILINEAR, true, true, false);
+          pd3dDevice->flasherShader->SetTexture(SHADER_tex_flasher_A, pinB, TextureFilter::TEXTURE_MODE_TRILINEAR, true, true, false);
 
           if (!m_d.m_addBlend)
              flasherData.x = pinB->m_alphaTestValue * (float)(1.0/255.0);
@@ -1263,8 +1263,8 @@ void Flasher::RenderDynamic()
        else if (pinA && pinB)
        {
           flasherMode = 1.f;
-          pd3dDevice->flasherShader->SetTexture(SHADER_Texture0, pinA, TextureFilter::TEXTURE_MODE_TRILINEAR, true, true, false);
-          pd3dDevice->flasherShader->SetTexture(SHADER_Texture1, pinB, TextureFilter::TEXTURE_MODE_TRILINEAR, true, true, false);
+          pd3dDevice->flasherShader->SetTexture(SHADER_tex_flasher_A, pinA, TextureFilter::TEXTURE_MODE_TRILINEAR, true, true, false);
+          pd3dDevice->flasherShader->SetTexture(SHADER_tex_flasher_B, pinB, TextureFilter::TEXTURE_MODE_TRILINEAR, true, true, false);
 
           if (!m_d.m_addBlend)
           {

--- a/flasher.cpp
+++ b/flasher.cpp
@@ -1216,7 +1216,7 @@ void Flasher::RenderDynamic()
        if (g_pplayer->m_texdmd != nullptr)
           pd3dDevice->DMDShader->SetTexture(SHADER_Texture0, g_pplayer->m_pin3d.m_pd3dPrimaryDevice->m_texMan.LoadTexture(g_pplayer->m_texdmd, TextureFilter::TEXTURE_MODE_NONE, true, true, false));
 
-       pd3dDevice->DMDShader->Begin(0);
+       pd3dDevice->DMDShader->Begin();
        pd3dDevice->DrawIndexedPrimitiveVB(RenderDevice::TRIANGLELIST, MY_D3DFVF_TEX, m_dynamicVertexBuffer, 0, m_numVertices, m_dynamicIndexBuffer, 0, m_numPolys * 3);
        pd3dDevice->DMDShader->End();
    }
@@ -1286,7 +1286,7 @@ void Flasher::RenderDynamic()
        pd3dDevice->SetRenderState(RenderDevice::DESTBLEND, m_d.m_addBlend ? RenderDevice::INVSRC_COLOR : RenderDevice::INVSRC_ALPHA);
        pd3dDevice->SetRenderState(RenderDevice::BLENDOP, m_d.m_addBlend ? RenderDevice::BLENDOP_REVSUBTRACT : RenderDevice::BLENDOP_ADD);
 
-       pd3dDevice->flasherShader->Begin(0);
+       pd3dDevice->flasherShader->Begin();
        pd3dDevice->DrawIndexedPrimitiveVB(RenderDevice::TRIANGLELIST, MY_D3DFVF_TEX, m_dynamicVertexBuffer, 0, m_numVertices, m_dynamicIndexBuffer, 0, m_numPolys * 3);
        pd3dDevice->flasherShader->End();
    }

--- a/flipper.cpp
+++ b/flipper.cpp
@@ -610,7 +610,7 @@ void Flipper::RenderDynamic()
    if (pin)
    {
       pd3dDevice->basicShader->SetTechniqueMetal(SHADER_TECHNIQUE_basic_with_texture, mat->m_bIsMetal);
-      pd3dDevice->basicShader->SetTexture(SHADER_Texture0, pin, TextureFilter::TEXTURE_MODE_TRILINEAR, false, false, false);
+      pd3dDevice->basicShader->SetTexture(SHADER_tex_base_color, pin, TextureFilter::TEXTURE_MODE_TRILINEAR, false, false, false);
       pd3dDevice->basicShader->SetAlphaTestValue(pin->m_alphaTestValue * (float)(1.0 / 255.0));
 
       //g_pplayer->m_pin3d.SetPrimaryTextureFilter(0, TEXTURE_MODE_TRILINEAR);

--- a/flipper.cpp
+++ b/flipper.cpp
@@ -635,7 +635,7 @@ void Flipper::RenderDynamic()
       matTrafo.Multiply(matTemp, matTrafo);
    }
    g_pplayer->UpdateBasicShaderMatrix(matTrafo);
-   pd3dDevice->basicShader->Begin(0);
+   pd3dDevice->basicShader->Begin();
    pd3dDevice->DrawIndexedPrimitiveVB(RenderDevice::TRIANGLELIST, MY_D3DFVF_NOTEX2_VERTEX, m_vertexBuffer, 0, flipperBaseVertices, m_indexBuffer, 0, flipperBaseNumIndices);
    pd3dDevice->basicShader->End();
 
@@ -649,7 +649,7 @@ void Flipper::RenderDynamic()
         pd3dDevice->basicShader->SetTechniqueMetal(SHADER_TECHNIQUE_basic_without_texture, mat->m_bIsMetal);
       pd3dDevice->basicShader->SetMaterial(mat);
 
-      pd3dDevice->basicShader->Begin(0);
+      pd3dDevice->basicShader->Begin();
       pd3dDevice->DrawIndexedPrimitiveVB(RenderDevice::TRIANGLELIST, MY_D3DFVF_NOTEX2_VERTEX, m_vertexBuffer, flipperBaseVertices, flipperBaseVertices, m_indexBuffer, 0, flipperBaseNumIndices);
       pd3dDevice->basicShader->End();
    }

--- a/gate.cpp
+++ b/gate.cpp
@@ -454,7 +454,7 @@ void Gate::RenderObject()
    pd3dDevice->SetRenderStateCulling(RenderDevice::CULL_CCW);
 
    pd3dDevice->basicShader->SetTechniqueMetal(SHADER_TECHNIQUE_basic_without_texture, mat->m_bIsMetal);
-   pd3dDevice->basicShader->Begin(0);
+   pd3dDevice->basicShader->Begin();
 
    // render bracket
    if (m_d.m_showBracket)

--- a/glshader/BallShader.glfx
+++ b/glshader/BallShader.glfx
@@ -238,24 +238,10 @@ void main()
 #else
    const float2 uv0 = %PARAM0% ? float2(r.y*m + 0.5, r.x*m + 0.5) : float2(r.x*m + 0.5, r.y*-m + 0.5);
 #endif
-<<<<<<< eb60b3afaa58dbc5aab6364ca9427fe6e8c04f7e
-   float3 ballImageColor = texture(Texture0, uv0).rgb;
-||||||| merged common ancestors
-	float3 ballImageColor = texture(Texture0, uv0).rgb;
-=======
-	float3 ballImageColor = texture(tex_ball_color, uv0).rgb;
->>>>>>> Fix erros between samplers and textures, makes code readable by using explicit sampler names instead of TextureX
+   float3 ballImageColor = texture(tex_ball_color, uv0).rgb;
 
-<<<<<<< eb60b3afaa58dbc5aab6364ca9427fe6e8c04f7e
-   const float4 decalColorT = texture(Texture3, vec2(normal_t0x.w, worldPos_t0y.w));
+   const float4 decalColorT = texture(tex_ball_decal, vec2(normal_t0x.w, worldPos_t0y.w));
    float3 decalColor = decalColorT.xyz;
-||||||| merged common ancestors
-	const float4 decalColorT = texture(Texture3, vec2(normal_t0x.w, worldPos_t0y.w));
-	float3 decalColor = decalColorT.xyz;
-=======
-	const float4 decalColorT = texture(tex_ball_decal, vec2(normal_t0x.w, worldPos_t0y.w));
-	float3 decalColor = decalColorT.xyz;
->>>>>>> Fix erros between samplers and textures, makes code readable by using explicit sampler names instead of TextureX
 
    if (!%PARAM1%) // decalMode
    {
@@ -299,13 +285,7 @@ void main()
 
       const float2 uv = (inverse(matWorldView) * vec4(playfield_hit, 1.0)).xy * invTableRes_playfield_height_reflection.xy;
       playfieldColor = (t < 0.) ? vec3(0., 0., 0.) // happens for example when inside kicker
-<<<<<<< eb60b3afaa58dbc5aab6364ca9427fe6e8c04f7e
-                                : texture(Texture1, uv).xyz*invTableRes_playfield_height_reflection.w; //!! rather use screen space sample from previous frame??
-||||||| merged common ancestors
-                              : texture(Texture1, uv).xyz*invTableRes_playfield_height_reflection.w; //!! rather use screen space sample from previous frame??
-=======
                               : texture(tex_ball_playfield, uv).xyz*invTableRes_playfield_height_reflection.w; //!! rather use screen space sample from previous frame??
->>>>>>> Fix erros between samplers and textures, makes code readable by using explicit sampler names instead of TextureX
 
       //!! hack to get some lighting on reflection sample, but only diffuse, the rest is not setup correctly anyhow
       playfieldColor = PFlightLoop(playfield_hit, playfield_normal, playfieldColor);

--- a/glshader/BallShader.glfx
+++ b/glshader/BallShader.glfx
@@ -34,10 +34,12 @@ layout(triangle_strip, max_vertices = 3) out;
 layout(early_fragment_tests) in;
 layout(depth_unchanged) out float gl_FragDepth;
 
-uniform sampler2D Texture0; // base texture
-uniform sampler2D Texture1; // playfield
-uniform sampler2D Texture2; // envmap radiance
-uniform sampler2D Texture3; // ball decal
+uniform sampler2D tex_ball_color; // base texture
+uniform sampler2D tex_ball_playfield; // playfield
+uniform sampler2D tex_ball_decal; // ball decal
+
+uniform sampler2D tex_env; // envmap
+uniform sampler2D tex_diffuse_env; // envmap radiance
 
 uniform bool is_metal = false;
 
@@ -236,10 +238,24 @@ void main()
 #else
    const float2 uv0 = %PARAM0% ? float2(r.y*m + 0.5, r.x*m + 0.5) : float2(r.x*m + 0.5, r.y*-m + 0.5);
 #endif
+<<<<<<< eb60b3afaa58dbc5aab6364ca9427fe6e8c04f7e
    float3 ballImageColor = texture(Texture0, uv0).rgb;
+||||||| merged common ancestors
+	float3 ballImageColor = texture(Texture0, uv0).rgb;
+=======
+	float3 ballImageColor = texture(tex_ball_color, uv0).rgb;
+>>>>>>> Fix erros between samplers and textures, makes code readable by using explicit sampler names instead of TextureX
 
+<<<<<<< eb60b3afaa58dbc5aab6364ca9427fe6e8c04f7e
    const float4 decalColorT = texture(Texture3, vec2(normal_t0x.w, worldPos_t0y.w));
    float3 decalColor = decalColorT.xyz;
+||||||| merged common ancestors
+	const float4 decalColorT = texture(Texture3, vec2(normal_t0x.w, worldPos_t0y.w));
+	float3 decalColor = decalColorT.xyz;
+=======
+	const float4 decalColorT = texture(tex_ball_decal, vec2(normal_t0x.w, worldPos_t0y.w));
+	float3 decalColor = decalColorT.xyz;
+>>>>>>> Fix erros between samplers and textures, makes code readable by using explicit sampler names instead of TextureX
 
    if (!%PARAM1%) // decalMode
    {
@@ -283,7 +299,13 @@ void main()
 
       const float2 uv = (inverse(matWorldView) * vec4(playfield_hit, 1.0)).xy * invTableRes_playfield_height_reflection.xy;
       playfieldColor = (t < 0.) ? vec3(0., 0., 0.) // happens for example when inside kicker
+<<<<<<< eb60b3afaa58dbc5aab6364ca9427fe6e8c04f7e
                                 : texture(Texture1, uv).xyz*invTableRes_playfield_height_reflection.w; //!! rather use screen space sample from previous frame??
+||||||| merged common ancestors
+                              : texture(Texture1, uv).xyz*invTableRes_playfield_height_reflection.w; //!! rather use screen space sample from previous frame??
+=======
+                              : texture(tex_ball_playfield, uv).xyz*invTableRes_playfield_height_reflection.w; //!! rather use screen space sample from previous frame??
+>>>>>>> Fix erros between samplers and textures, makes code readable by using explicit sampler names instead of TextureX
 
       //!! hack to get some lighting on reflection sample, but only diffuse, the rest is not setup correctly anyhow
       playfieldColor = PFlightLoop(playfield_hit, playfield_normal, playfieldColor);
@@ -318,7 +340,7 @@ vec4 psBallReflection( in voutReflection IN ) : COLOR
 {
    vec2 envTex = /*cabMode*/false ? vec2(r.y*0.5f + 0.5f, -r.x*0.5f + 0.5f) : vec2(r.x*0.5f + 0.5f, r.y*0.5f + 0.5f);
 
-   vec3 ballImageColor = texture(Texture0, envTex).rgb;
+   vec3 ballImageColor = texture(tex_ball_color, envTex).rgb;
 
    ballImageColor = (cBase_Alpha.xyz*(0.075*0.25) + ballImageColor)*fenvEmissionScale_TexWidth.x; //!! just add the ballcolor in, this is a whacky reflection anyhow
    float alpha = clamp((tex0.y - position_radius.y) / position_radius.w, 0.0, 1.0);
@@ -333,7 +355,7 @@ in vec3 tex0_alpha;
 
 void main()
 {
-   vec3 ballImageColor = texture(Texture0, tex0_alpha.xy).rgb;
+   vec3 ballImageColor = texture(tex_ball_color, tex0_alpha.xy).rgb;
    if (disableLighting)
       color = vec4(ballImageColor, tex0_alpha.z);
    else

--- a/glshader/BasicShader.glfx
+++ b/glshader/BasicShader.glfx
@@ -41,11 +41,11 @@ layout(triangle_strip, max_vertices = 3) out;
 //layout(early_fragment_tests) in;
 layout(depth_unchanged) out float gl_FragDepth;
 
-uniform sampler2D Texture0; // base texture
-uniform sampler2D Texture1; // envmap
-uniform sampler2D Texture2; // envmap radiance
-uniform sampler2D Texture3; // bulb light buffer
-uniform sampler2D Texture4; // normal map
+uniform sampler2D tex_base_color; // base texture
+uniform sampler2D tex_env; // envmap
+uniform sampler2D tex_diffuse_env; // envmap radiance
+uniform sampler2D tex_base_transmission; // bulb light buffer
+uniform sampler2D tex_base_normalmap; // normal map
 
 uniform bool objectSpaceNormalMap;
 uniform bool is_metal;
@@ -87,7 +87,7 @@ mat3 TBN_trafo(vec3 N, vec3 V, vec2 uv)
 
 vec3 normal_map(vec3 N, vec3 V, vec2 uv)
 {
-   vec3 tn = texture(Texture4, uv).xyz * (255./127.) - (128./127.); // Note that Blender apparently does export tangent space normalmaps for Z (Blue) at full range, so 0..255 -> 0..1, which misses an option for here!
+   vec3 tn = texture(tex_base_normalmap, uv).xyz * (255./127.) - (128./127.); // Note that Blender apparently does export tangent space normalmaps for Z (Blue) at full range, so 0..255 -> 0..1, which misses an option for here!
 
    if (objectSpaceNormalMap)
    {
@@ -318,7 +318,7 @@ void main() {
 
       if (fDisableLighting_top_below.y < 1.0)
           // add light from "below" from user-flagged bulb lights, pre-rendered/blurred in previous renderpass //!! sqrt = magic
-          color.xyz += mix(sqrt(diffuse)*texture(Texture3, vec2(0.5*tex03.xy)+0.5, 0).xyz*color.a, vec3(0.), fDisableLighting_top_below.y); //!! depend on normal of light (unknown though) vs geom normal, too?
+          color.xyz += mix(sqrt(diffuse)*texture(tex_base_transmission, vec2(0.5*tex03.xy)+0.5, 0).xyz*color.a, vec3(0.), fDisableLighting_top_below.y); //!! depend on normal of light (unknown though) vs geom normal, too?
    }
 
    color *= staticColor_Alpha;
@@ -332,7 +332,7 @@ in vec3 worldPos;
 in vec3 normal;
 
 void main() {
-   vec4 pixel = texture(Texture0, tex01);
+   vec4 pixel = texture(tex_base_color, tex01);
 
    if (pixel.a <= alphaTestValue)
       discard;           //stop the pixel shader if alpha test should reject pixel
@@ -364,7 +364,7 @@ void main() {
       if (fDisableLighting_top_below.y < 1.0)
       {
          // add light from "below" from user-flagged bulb lights, pre-rendered/blurred in previous renderpass //!! sqrt = magic
-         color.xyz += mix(sqrt(diffuse)*texture(Texture3, vec2(0.5*tex03.xy)+0.5).xyz*color.a, vec3(0.), fDisableLighting_top_below.y); //!! depend on normal of light (unknown though) vs geom normal, too?
+         color.xyz += mix(sqrt(diffuse)*texture(tex_base_transmission, vec2(0.5*tex03.xy)+0.5).xyz*color.a, vec3(0.), fDisableLighting_top_below.y); //!! depend on normal of light (unknown though) vs geom normal, too?
       }
    }
 
@@ -382,7 +382,7 @@ void main() {
 in vec2 tex0;
 
 void main() {
-   if (textureLod(Texture0, tex0, 0).a <= alphaTestValue)
+   if (textureLod(tex_base_color, tex0, 0).a <= alphaTestValue)
       discard;           //stop the pixel shader if alpha test should reject pixel
 
    color = vec4(0., 0., 0., 1.);
@@ -401,7 +401,7 @@ void main() {
 in vec2 tex01;
 
 void main() {
-   vec4 pixel = texture(Texture0, tex01);
+   vec4 pixel = texture(tex_base_color, tex01);
 
    //if (pixel.a <= alphaTestValue) discard;
 

--- a/glshader/ClassicLightShader.glfx
+++ b/glshader/ClassicLightShader.glfx
@@ -5,6 +5,8 @@ uniform vec4 lightColor2_falloff_power;
 uniform vec4 lightCenter_maxRange;
 uniform vec2 imageBackglassMode; // actually bool2
 
+uniform sampler2D tex_light_color; // base texture
+
 ////vs_light_main
 
 in vec3 vPosition;
@@ -72,7 +74,8 @@ in vec3 normal;
 
 void main()
 {
-    vec4 pixel = textureLod(Texture0, tex0, 0); //!! IN.tex0 abused in backglass mode
+   // FIXME check tex_light_color declaration
+    vec4 pixel = textureLod(tex_light_color, tex0, 0); //!! IN.tex0 abused in backglass mode
 
     // no lighting if HUD vertices or passthrough mode
     if(imageBackglassMode.x != 0. || imageBackglassMode.y != 0.)

--- a/glshader/DMDShader.glfx
+++ b/glshader/DMDShader.glfx
@@ -29,7 +29,8 @@ layout(triangle_strip, max_vertices = 3) out;
 
 ////FRAGMENT
 
-uniform sampler2D Texture0; // base texture
+uniform sampler2D tex_dmd; // base texture for DMD (unfiltered)
+uniform sampler2D tex_sprite; // base texture for sprites (filtered)
 
 out vec4 color;
 
@@ -178,7 +179,7 @@ void main()
 		 
       const float2 uv = tex0 + /*gxi.x*ddxs + gxi.y*ddys; /*/ triangularPDF(xi.x)*ddxs + triangularPDF(xi.y)*ddys; //!! lots of ALU
 
-      const float4 rgba = texture(Texture0, uv, 0.0); //!! lots of tex access by doing this all the time, but (tex) cache should be able to catch all of it
+      const float4 rgba = texture(tex_dmd, uv, 0.0); //!! lots of tex access by doing this all the time, but (tex) cache should be able to catch all of it
 
 
       // simulate dot within the sampled texel
@@ -211,7 +212,7 @@ in vec2 tex0;
 
 void main()
 {
-   vec4 rgba = texture(Texture0, tex0);
+   vec4 rgba = texture(tex_dmd, tex0);
    color.rgb = rgba.rgb;
    color.a = vRes_Alpha_time.z;
 }
@@ -222,7 +223,7 @@ in vec2 tex0;
 
 void main()
 {
-   const float4 l = tex2D(Texture0, tex0);
+   const float4 l = tex2D(tex_sprite, tex0);
 
    color = float4(InvToneMap(/*InvGamma*/(l.xyz * vColor_Intensity.xyz * vColor_Intensity.w)), l.w); //!! meh, this sucks a bit performance-wise, but how to avoid this when doing fullscreen-tonemap/gamma without stencil and depth read?
 }

--- a/glshader/DMDShaderVR.glfx
+++ b/glshader/DMDShaderVR.glfx
@@ -46,7 +46,8 @@ vec3 InvToneMap( vec3 color)
    return (color - 1.0 + sqrt(color*(color + bh) + 1.0))*inv_2bh;
 }
 
-uniform sampler2D Texture0; // base texture
+uniform sampler2D tex_dmd; // base texture for DMD (unfiltered)
+uniform sampler2D tex_sprite; // base texture for sprites (filtered)
 
 out vec4 color;
 
@@ -142,7 +143,7 @@ void main()
         {
             vec2 uv = uvj + float(i) * ddxs;
 
-            vec4 rgba = texture(Texture0, uv); //!! lots of tex access by doing this all the time, but (tex) cache should be able to catch all of it
+            vec4 rgba = texture(tex_dmd, uv); //!! lots of tex access by doing this all the time, but (tex) cache should be able to catch all of it
             color.rgb = vColor_Intensity.xyz * vColor_Intensity.w; //!! create function that resembles LUT from VPM?
             if (rgba.a != 0.0)
                 color.rgb *= rgba.rgb;
@@ -177,7 +178,7 @@ in vec2 tex0;
 
 void main()
 {
-   vec4 rgba = texture(Texture0, tex0); //!! lots of tex access by doing this all the time, but (tex) cache should be able to catch all of it
+   vec4 rgba = texture(tex_dmd, tex0); //!! lots of tex access by doing this all the time, but (tex) cache should be able to catch all of it
    color.rgb = rgba.rgb;
    color.a = vRes_Alpha_time.z;
 }
@@ -188,7 +189,7 @@ in vec2 tex0;
 
 void main()
 {
-   vec4 l = texture(Texture0, tex0);
+   vec4 l = texture(tex_sprite, tex0);
 
    color = vec4(InvToneMap(InvGamma(l.xyz * vColor_Intensity.xyz * vColor_Intensity.w)), l.w); //!! meh, this sucks a bit performance-wise, but how to avoid this when doing fullscreen-tonemap/gamma without stencil and depth read?
 }

--- a/glshader/FBShader.glfx
+++ b/glshader/FBShader.glfx
@@ -16,10 +16,16 @@ uniform bool color_grade;
 uniform bool do_dither;
 uniform bool do_bloom;
 
-uniform sampler2D Texture0; // FB
-uniform sampler2D Texture1; // Bloom
-uniform sampler2D Texture3; // AO Result & DepthBuffer
-uniform sampler2D Texture4; // AO Dither, Color grade and Post Processing
+uniform sampler2D tex_fb_filtered; // Framebuffer (filtered)
+uniform sampler2D tex_fb_unfiltered; // Framebuffer (unfiltered)
+uniform sampler2D tex_mirror; // Base mirror texture
+uniform sampler2D tex_bloom; // Bloom
+uniform sampler2D tex_ao; // AO Result
+uniform sampler2D tex_depth; // Depth
+uniform sampler2D tex_color_lut; // Color grade LUT
+uniform sampler2D tex_ao_dither; // AO dither
+uniform sampler2D tex_normals; // Normals
+
 
 out vec4 color;
 
@@ -163,8 +169,8 @@ vec3 FBColorGrade(vec3 color)
    color.z *= 15.0;
 
    float x = (color.x + floor(color.z))/16.0;
-   vec3 lut1 = textureLod(Texture4, vec2(x,          color.y), 0).xyz; // two lookups to blend/lerp between blue 2D regions
-   vec3 lut2 = textureLod(Texture4, vec2(x+1.0/16.0, color.y), 0).xyz;
+   vec3 lut1 = textureLod(tex_color_lut, vec2(x,          color.y), 0).xyz; // two lookups to blend/lerp between blue 2D regions
+   vec3 lut2 = textureLod(tex_color_lut, vec2(x+1.0/16.0, color.y), 0).xyz;
    return mix(lut1,lut2, frac(color.z));
 }
 
@@ -191,13 +197,13 @@ in vec2 tex0;
 
 void main()
 {
-   //!! float depth0 = tex2Dlod(Texture3, vec4(u, 0.,0.)).x;
+   //!! float depth0 = tex2Dlod(tex_depth, vec4(u, 0.,0.)).x;
    //!! if((depth0 == 1.0) || (depth0 == 0.0)) //!! early out if depth too large (=BG) or too small (=DMD,etc -> retweak render options (depth write on), otherwise also screwup with stereo)
-   //!!   return vec4(tex2Dlod(Texture0, vec4(tex0, 0.,0.)).xyz, 1.0);
+   //!!   return vec4(tex2Dlod(tex_fb_filtered, vec4(tex0, 0.,0.)).xyz, 1.0);
 
-   vec3 result = FBToneMap(textureLod(Texture0, tex0, 0).xyz);
+   vec3 result = FBToneMap(textureLod(tex_fb_filtered, tex0, 0).xyz);
    if (do_bloom)
-      result += textureLod(Texture1, tex0, 0.).xyz; //!! offset?
+      result += textureLod(tex_bloom, tex0, 0.).xyz; //!! offset?
    color = vec4(FBColorGrade(FBGamma(clamp(result, 0.0, 1.0))), 1.0);
 }
 
@@ -207,10 +213,10 @@ in vec2 tex0;
 
 void main()
 {
-   vec3 result = (texture(Texture1, vec2(tex0-w_h_height.xy*0.5)).xyz
-               +  texture(Texture1, vec2(tex0+w_h_height.xy*2.5)).xyz
-               +  texture(Texture1, vec2(tex0+vec2(w_h_height.x*2.5,-w_h_height.y*0.5))).xyz
-               +  texture(Texture1, vec2(tex0+vec2(-w_h_height.x*0.5,w_h_height.y*2.5))).xyz)*0.25; //!! offset for useAA?
+   vec3 result = (texture(tex_fb_filtered, vec2(tex0-w_h_height.xy*0.5)).xyz
+               +  texture(tex_fb_filtered, vec2(tex0+w_h_height.xy*2.5)).xyz
+               +  texture(tex_fb_filtered, vec2(tex0+vec2(w_h_height.x*2.5,-w_h_height.y*0.5))).xyz
+               +  texture(tex_fb_filtered, vec2(tex0+vec2(-w_h_height.x*0.5,w_h_height.y*2.5))).xyz)*0.25; //!! offset for useAA?
    color = vec4(max(FBToneMap(result) - vec3(1., 1., 1.), vec3(0., 0., 0.)), 1.0);
 }
 
@@ -220,7 +226,7 @@ in vec2 tex0;
 
 void main()
 {
-   vec3 result = vec3(textureLod(Texture3, tex0/*-w_h_height.xy*/, 0).x); // omitting the shift blurs over 2x2 window
+   vec3 result = vec3(textureLod(tex_ao, tex0/*-w_h_height.xy*/, 0).x); // omitting the shift blurs over 2x2 window
    color = vec4(FBGamma(saturate(result)), 1.0);
 }
 
@@ -230,10 +236,10 @@ in vec2 tex0;
 
 void main()
 {
-   vec3 result = FBToneMap(textureLod(Texture0, tex0, 0).xyz) // moving AO before tonemap does not really change the look
-                         * textureLod(Texture3, tex0/*-w_h_height.xy*/, 0).x; // omitting the shift blurs over 2x2 window
+   vec3 result = FBToneMap(textureLod(tex_fb_filtered, tex0, 0).xyz) // moving AO before tonemap does not really change the look
+                         * textureLod(tex_ao, tex0/*-w_h_height.xy*/, 0).x; // omitting the shift blurs over 2x2 window
    if (do_bloom)
-      result += textureLod(Texture1, tex0, 0).xyz; //!! offset?
+      result += textureLod(tex_bloom, tex0, 0).xyz; //!! offset?
    color = vec4(FBColorGrade(FBGamma(clamp(result, 0.0, 1.0))), 1.0);
 }
 
@@ -243,8 +249,8 @@ in vec2 tex0;
 
 void main()
 {
-   vec3 result = textureLod(Texture0, tex0, 0).xyz
-               * textureLod(Texture3, tex0/*-w_h_height.xy*/, 0).x; // omitting the shift blurs over 2x2 window
+   vec3 result = textureLod(tex_fb_filtered, tex0, 0).xyz
+               * textureLod(tex_ao, tex0/*-w_h_height.xy*/, 0).x; // omitting the shift blurs over 2x2 window
    color = vec4(result, 1.0);
 }
 
@@ -254,9 +260,9 @@ in vec2 tex0;
 
 void main()
 {
-   vec3 result = FBToneMap(textureLod(Texture0, tex0+w_h_height.xy, 0).xyz);
+   vec3 result = FBToneMap(textureLod(tex_fb_unfiltered, tex0+w_h_height.xy, 0).xyz);
    if (do_bloom)
-      result += textureLod(Texture1, tex0, 0).xyz; //!! offset?
+      result += textureLod(tex_bloom, tex0, 0).xyz; //!! offset?
    color = vec4(/*FBDither(*/FBColorGrade(FBGamma(clamp(result, 0.0, 1.0))),/*tex0*w_h_height.zw),*/ 1.0);
 }
 
@@ -266,10 +272,10 @@ in vec2 tex0;
 
 void main()
 {
-   //vec3 result = FBToneMap(textureLod(Texture0, tex0+w_h_height.xy, 0).xyz);
-   vec3 result = FBToneMap(textureLod(Texture0, tex0, 0).xyz);
+   //vec3 result = FBToneMap(textureLod(tex_fb_unfiltered, tex0+w_h_height.xy, 0).xyz);
+   vec3 result = FBToneMap(textureLod(tex_fb_unfiltered, tex0, 0).xyz);
    if (do_bloom)
-      result += textureLod(Texture1, tex0, 0).xyz; //!! offset?
+      result += textureLod(tex_bloom, tex0, 0).xyz; //!! offset?
    color = vec4(FBColorGrade(FBGamma(clamp(FBDither(result, tex0), 0.0, 1.0))), 1.0);
 }
 
@@ -279,9 +285,9 @@ in vec2 tex0;
 
 void main()
 {
-   float result = FBToneMap(textureLod(Texture0,tex0+w_h_height.xy, 0).xyz).x;
+   float result = FBToneMap(textureLod(tex_fb_unfiltered,tex0+w_h_height.xy, 0).xyz).x;
    if (do_bloom)
-      result += textureLod(Texture1, tex0, 0).x; //!! offset?
+      result += textureLod(tex_bloom, tex0, 0).x; //!! offset?
    float gray = /*FBDither(*//*FBColorGrade*/(FBGamma(vec3(clamp(result, 0.0, 1.0)))).x/*,tex0*w_h_height.zw)*/;
    color = vec4(gray,gray,gray,1.0);
 }
@@ -292,10 +298,10 @@ in vec2 tex0;
 
 void main()
 {
-   vec3 result = FBToneMap(textureLod(Texture0, tex0+w_h_height.xy, 0).xyz) // moving AO before tonemap does not really change the look
-                         * textureLod(Texture3, tex0/*-w_h_height.xy*/, 0).x; // omitting the shift blurs over 2x2 window
+   vec3 result = FBToneMap(textureLod(tex_fb_unfiltered, tex0+w_h_height.xy, 0).xyz) // moving AO before tonemap does not really change the look
+                         * textureLod(tex_bloom, tex0/*-w_h_height.xy*/, 0).x; // omitting the shift blurs over 2x2 window
    if (do_bloom)
-      result += textureLod(Texture1, tex0, 0).xyz;  //!! offset?
+      result += textureLod(tex_bloom, tex0, 0).xyz;  //!! offset?
    color = vec4(FBColorGrade(FBGamma(clamp(result, 0.0, 1.0))), 1.0);
 }
 
@@ -305,10 +311,10 @@ in vec2 tex0;
 
 void main()
 {
-   vec3 result = FBToneMap(textureLod(Texture0, tex0+w_h_height.xy, 0).xyz) // moving AO before tonemap does not really change the look
-                         * textureLod(Texture0, tex0/*-w_h_height.xy*/, 0).x; // omitting the shift blurs over 2x2 window
+   vec3 result = FBToneMap(textureLod(tex_fb_unfiltered, tex0+w_h_height.xy, 0).xyz) // moving AO before tonemap does not really change the look
+                         * textureLod(tex_fb_unfiltered, tex0/*-w_h_height.xy*/, 0).x; // omitting the shift blurs over 2x2 window
    if (do_bloom)
-      result += textureLod(Texture1, tex0, 0).xyz;  //!! offset?
+      result += textureLod(tex_bloom, tex0, 0).xyz;  //!! offset?
    color = vec4(FBColorGrade(FBGamma(saturate(FBDither(result, tex0)))), 1.0);
 }
 
@@ -318,8 +324,8 @@ in vec2 tex0;
 
 void main()
 {
-   vec3 result = textureLod(Texture0, tex0 + w_h_height.xy, 0).xyz
-               * textureLod(Texture3, tex0/*-w_h_height.xy*/, 0).x; // omitting the shift blurs over 2x2 window
+   vec3 result = textureLod(tex_fb_unfiltered, tex0 + w_h_height.xy, 0).xyz
+               * textureLod(tex_ao, tex0/*-w_h_height.xy*/, 0).x; // omitting the shift blurs over 2x2 window
    color = vec4(result, 1.0);
 }
 
@@ -334,10 +340,10 @@ void main()
 {
    const float offset9x9[3] = float[]( 0.0, 1.3846153846, 3.2307692308 );
    const float weight9x9[3] = float[]( 0.2270270270, 0.3162162162, 0.0702702703 );
-   vec3 result = texture(Texture1, tex0+w_h_height.xy*0.5).xyz*weight9x9[0];
+   vec3 result = texture(tex_fb_filtered, tex0+w_h_height.xy*0.5).xyz*weight9x9[0];
    for (int i = 1; i < 3; ++i)
-      result += (texture(Texture1, vec2(tex0+w_h_height.xy*0.5+vec2(w_h_height.x*offset9x9[i],0.0))).xyz
-                +texture(Texture1, vec2(tex0+w_h_height.xy*0.5-vec2(w_h_height.x*offset9x9[i],0.0))).xyz)*weight9x9[i];
+      result += (texture(tex_fb_filtered, vec2(tex0+w_h_height.xy*0.5+vec2(w_h_height.x*offset9x9[i],0.0))).xyz
+                +texture(tex_fb_filtered, vec2(tex0+w_h_height.xy*0.5-vec2(w_h_height.x*offset9x9[i],0.0))).xyz)*weight9x9[i];
 
    color = vec4(result, 1.0);
 }
@@ -349,10 +355,10 @@ void main()
 {
    const float offset9x9[3] = float[]( 0.0, 1.3846153846, 3.2307692308 );
    const float weight9x9[3] = float[]( 0.2270270270, 0.3162162162, 0.0702702703 );
-   vec3 result = texture(Texture1, vec2(tex0+w_h_height.xy*0.5)).xyz*weight9x9[0];
+   vec3 result = texture(tex_fb_unfiltered, vec2(tex0+w_h_height.xy*0.5)).xyz*weight9x9[0];
    for (int i = 1; i < 3; ++i)
-      result += (texture(Texture1, vec2(tex0+w_h_height.xy*0.5+vec2(0.0,w_h_height.y*offset9x9[i]))).xyz
-                +texture(Texture1, vec2(tex0+w_h_height.xy*0.5-vec2(0.0,w_h_height.y*offset9x9[i]))).xyz)*weight9x9[i];
+      result += (texture(tex_fb_filtered, vec2(tex0+w_h_height.xy*0.5+vec2(0.0,w_h_height.y*offset9x9[i]))).xyz
+                +texture(tex_fb_filtered, vec2(tex0+w_h_height.xy*0.5-vec2(0.0,w_h_height.y*offset9x9[i]))).xyz)*weight9x9[i];
 
    color = vec4(result*w_h_height.z, 1.0);
 }
@@ -366,8 +372,8 @@ void main()
    const float weight19x19[5] = float[]( 0.19923, 0.18937, 0.08396, 0.02337, 0.00408 ); //no center!
    vec3 result = vec3(0.0, 0.0, 0.0);
    for(int i = 0; i < 5; ++i)
-      result += (texture(Texture1, vec2(tex0+w_h_height.xy*0.5+vec2(w_h_height.x*offset19x19[i],0.0))).xyz
-                +texture(Texture1, vec2(tex0+w_h_height.xy*0.5-vec2(w_h_height.x*offset19x19[i],0.0))).xyz)*weight19x19[i];
+      result += (texture(tex_fb_filtered, vec2(tex0+w_h_height.xy*0.5+vec2(w_h_height.x*offset19x19[i],0.0))).xyz
+                +texture(tex_fb_filtered, vec2(tex0+w_h_height.xy*0.5-vec2(w_h_height.x*offset19x19[i],0.0))).xyz)*weight19x19[i];
 
    color = vec4(result, 1.0);
 }
@@ -382,8 +388,8 @@ void main()
    const float weight19x19[5] = float[]( 0.19923, 0.18937, 0.08396, 0.02337, 0.00408 ); //no center!
    vec3 result = vec3(0.0, 0.0, 0.0);
    for(int i = 0; i < 5; ++i)
-      result += (texture(Texture1, vec2(tex0+w_h_height.xy*0.5+vec2(0.0,w_h_height.y*offset19x19[i]))).xyz
-                +texture(Texture1, vec2(tex0+w_h_height.xy*0.5-vec2(0.0,w_h_height.y*offset19x19[i]))).xyz)*weight19x19[i];
+      result += (texture(tex_fb_filtered, vec2(tex0+w_h_height.xy*0.5+vec2(0.0,w_h_height.y*offset19x19[i]))).xyz
+                +texture(tex_fb_filtered, vec2(tex0+w_h_height.xy*0.5-vec2(0.0,w_h_height.y*offset19x19[i]))).xyz)*weight19x19[i];
 
    color = vec4(result*w_h_height.z, 1.0);
 }
@@ -403,8 +409,8 @@ void main()
    const float weight19x19h[5] = float[]( 0.27233, 0.18690, 0.03767, 0.00301, 0.00009 ); //no center!
    vec3 result = vec3(0.0, 0.0, 0.0);
    for(int i = 0; i < 5; ++i)
-      result += (texture(Texture1, vec2(tex0+w_h_height.xy*0.5+vec2(w_h_height.x*offset19x19h[i],0.0))).xyz
-                +texture(Texture1, vec2(tex0+w_h_height.xy*0.5-vec2(w_h_height.x*offset19x19h[i],0.0))).xyz)*weight19x19h[i];
+      result += (texture(tex_fb_filtered, vec2(tex0+w_h_height.xy*0.5+vec2(w_h_height.x*offset19x19h[i],0.0))).xyz
+                +texture(tex_fb_filtered, vec2(tex0+w_h_height.xy*0.5-vec2(w_h_height.x*offset19x19h[i],0.0))).xyz)*weight19x19h[i];
 
    color = vec4(result, 1.0);
 }
@@ -419,8 +425,8 @@ void main()
    const float weight19x19h[5] = float[]( 0.27233, 0.18690, 0.03767, 0.00301, 0.00009 ); //no center!
    vec3 result = vec3(0.0, 0.0, 0.0);
    for(int i = 0; i < 5; ++i)
-      result += (texture(Texture1, vec2(tex0+w_h_height.xy*0.5+vec2(0.0,w_h_height.y*offset19x19h[i]))).xyz
-                +texture(Texture1, vec2(tex0+w_h_height.xy*0.5-vec2(0.0,w_h_height.y*offset19x19h[i]))).xyz)*weight19x19h[i];
+      result += (texture(tex_fb_filtered, vec2(tex0+w_h_height.xy*0.5+vec2(0.0,w_h_height.y*offset19x19h[i]))).xyz
+                +texture(tex_fb_filtered, vec2(tex0+w_h_height.xy*0.5-vec2(0.0,w_h_height.y*offset19x19h[i]))).xyz)*weight19x19h[i];
 
    color = vec4(result*w_h_height.z, 1.0);
 }
@@ -440,8 +446,8 @@ void main()
                                           /*0.09721, 0.11993, 0.09955, 0.07429, 0.04984, 0.03006, 0.01630, 0.00795, 0.00348, 0.00137*/ ); //no center!
     float3 result = float3(0.0, 0.0, 0.0);
     for(int i = 0; i < 10; ++i)
-        result += (texture(Texture1, vec2(tex0+w_h_height.xy*0.5+vec2(w_h_height.x*offset39x39[i],0.0))).xyz
-                  +texture(Texture1, vec2(tex0+w_h_height.xy*0.5-vec2(w_h_height.x*offset39x39[i],0.0))).xyz)*weight39x39[i];
+        result += (texture(tex_fb_filtered, vec2(tex0+w_h_height.xy*0.5+vec2(w_h_height.x*offset39x39[i],0.0))).xyz
+                  +texture(tex_fb_filtered, vec2(tex0+w_h_height.xy*0.5-vec2(w_h_height.x*offset39x39[i],0.0))).xyz)*weight39x39[i];
 
     color = float4(result, 1.0);
 }
@@ -460,8 +466,8 @@ void main()
                                           /*0.09721, 0.11993, 0.09955, 0.07429, 0.04984, 0.03006, 0.01630, 0.00795, 0.00348, 0.00137*/ ); //no center!
     float3 result = float3(0.0, 0.0, 0.0);
     for(int i = 0; i < 10; ++i)
-        result += (texture(Texture1, vec2(tex0+w_h_height.xy*0.5+vec2(0.0,w_h_height.y*offset39x39[i]))).xyz
-                  +texture(Texture1, vec2(tex0+w_h_height.xy*0.5-vec2(0.0,w_h_height.y*offset39x39[i]))).xyz)*weight39x39[i];
+        result += (texture(tex_fb_filtered, vec2(tex0+w_h_height.xy*0.5+vec2(0.0,w_h_height.y*offset39x39[i]))).xyz
+                  +texture(tex_fb_filtered, vec2(tex0+w_h_height.xy*0.5-vec2(0.0,w_h_height.y*offset39x39[i]))).xyz)*weight39x39[i];
 
     color = float4(result*w_h_height.z, 1.0);
 }
@@ -472,7 +478,7 @@ in vec2 tex0;
 
 void main()
 {
-   color = texture(Texture0, tex0) * mirrorFactor;
+   color = texture(tex_mirror, tex0) * mirrorFactor;
 }
 
 

--- a/glshader/FXAAStereoAO.fxh
+++ b/glshader/FXAAStereoAO.fxh
@@ -22,8 +22,8 @@ float2 hash(float2 gridcell)
 
 float3 get_nonunit_normal(float depth0, float2 u) // use neighboring pixels // quite some tex access by this
 {
-	float depth1 = textureLod(Texture4, float2(u.x, u.y+w_h_height.y), 0).x;
-	float depth2 = textureLod(Texture4, float2(u.x+w_h_height.x, u.y), 0).x;
+	float depth1 = textureLod(tex_depth, float2(u.x, u.y+w_h_height.y), 0).x;
+	float depth2 = textureLod(tex_depth, float2(u.x+w_h_height.x, u.y), 0).x;
 	return float3(w_h_height.y * (depth2 - depth0), (depth1 - depth0) * w_h_height.x, w_h_height.y * w_h_height.x); //!!
 }
 
@@ -72,13 +72,13 @@ void main()
 	float2 uv0 = tex0 + w_h_height.xy; // half pixel shift in x & y for filter
 	float2 uv1 = tex0;                 // dto.
 
-	float depth0 = textureLod(Texture0, u, 0).x;
+	float depth0 = textureLod(tex_depth, u, 0).x;
 	if((depth0 == 1.0) || (depth0 == 0.0)) //!! early out if depth too large (=BG) or too small (=DMD,etc -> retweak render options (depth write on), otherwise also screwup with stereo)
 		color = float4(1.0, 0.,0.,0.);
 	else {
 
 		float3 ushift = /*hash(tex0) + w_h_height.zw*/ // jitter samples via hash of position on screen and then jitter samples by time //!! see below for non-shifted variant
-							  textureLod(Texture4, tex0/(64.0*w_h_height.xy) + w_h_height.zw, 0).xyz; // use dither texture instead nowadays // 64 is the hardcoded dither texture size for AOdither.bmp
+							  textureLod(tex_ao_dither, tex0/(64.0*w_h_height.xy) + w_h_height.zw, 0).xyz; // use dither texture instead nowadays // 64 is the hardcoded dither texture size for AOdither.bmp
 		//float base = 0.0;
 		float area = 0.06; //!!
 		float falloff = 0.0002; //!!
@@ -88,7 +88,7 @@ void main()
 		float depth_threshold_normal = 0.005;
 		float total_strength = AO_scale_timeblur.x * (/*1.0 for uniform*/0.5 / samples);
 		float3 normal = normalize(get_nonunit_normal(depth0, u));
-		//float3 normal = tex2Dlod(Texture1, float4(u, 0.,0.)).xyz *2.0-1.0; // use 8bitRGB pregenerated normals
+		//float3 normal = tex2Dlod(tex_normals, float4(u, 0.,0.)).xyz *2.0-1.0; // use 8bitRGB pregenerated normals
 		float radius_depth = radius/depth0;
 
 		float occlusion = 0.0;
@@ -99,19 +99,19 @@ void main()
 			//!! maybe a bit worse distribution: float2 ray = cos_hemisphere_sample(normal,frac(r+ushift.xy)).xy; // shift lattice
 			//float rdotn = dot(ray,normal);
 			float2 hemi_ray = u + (radius_depth /** sign(rdotn) for uniform*/) * ray.xy;
-			float occ_depth = textureLod(Texture0, hemi_ray, 0).x;
+			float occ_depth = textureLod(tex_depth, hemi_ray, 0).x;
 			float3 occ_normal = get_nonunit_normal(occ_depth, hemi_ray);
-			//float3 occ_normal = tex2Dlod(Texture1, float4(hemi_ray, 0.,0.)).xyz *2.0-1.0;  // use 8bitRGB pregenerated normals, can also omit normalization below then
+			//float3 occ_normal = tex2Dlod(tex_normals, float4(hemi_ray, 0.,0.)).xyz *2.0-1.0;  // use 8bitRGB pregenerated normals, can also omit normalization below then
 			float diff_depth = depth0 - occ_depth;
 			float diff_norm = dot(occ_normal,normal);
 			occlusion += step(falloff, diff_depth) * /*abs(rdotn)* for uniform*/ (diff_depth < depth_threshold_normal ? (1.0-diff_norm*diff_norm/dot(occ_normal,occ_normal)) : 1.0) * (1.0-smoothstep(falloff, area, diff_depth));
 		}
 		// weight with result(s) from previous frames
 		float ao = 1.0 - total_strength * occlusion;
-      color = float4( (textureLod(Texture0, uv0, 0).x //abuse bilerp for filtering (by using half texel/pixel shift)
-                  +textureLod(Texture0, uv1, 0).x
-                  +textureLod(Texture0, float2(uv0.x, uv1.y), 0).x
-                  +textureLod(Texture0, float2(uv1.x, uv0.y), 0).x)
+      color = float4( (textureLod(tex_fb_filtered, uv0, 0).x //abuse bilerp for filtering (by using half texel/pixel shift)
+                  +textureLod(tex_fb_filtered, uv1, 0).x
+                  +textureLod(tex_fb_filtered, float2(uv0.x, uv1.y), 0).x
+                  +textureLod(tex_fb_filtered, float2(uv1.x, uv0.y), 0).x)
          *(0.25*(1.0-AO_scale_timeblur.y))+saturate(ao /*+base*/)*AO_scale_timeblur.y, 0.,0.,0.);
 	}
 }
@@ -137,23 +137,23 @@ void main()
 	if(topdown) { u.y *= 2.0; if(!l) u.y -= 1.0; }  //!! !topdown: (u.y+w_h_height.y) ?
 	else if(sidebyside) { u.x *= 2.0; if(!l) u.x -= 1.0; }
 	float su = l ? MaxSeparation : -MaxSeparation;
-	float minDepth = min(min(textureLod(Texture4, u + (yaxis ? float2(0.0,0.5*su) : float2(0.5*su,0.0)), 0).x, textureLod(Texture4, u + (yaxis ? float2(0.0,0.666*su) : float2(0.666*su,0.0)), 0).x), textureLod(Texture4, u + (yaxis ? float2(0.0,su) : float2(su,0.0)), 0).x);
+	float minDepth = min(min(textureLod(tex_depth, u + (yaxis ? float2(0.0,0.5*su) : float2(0.5*su,0.0)), 0).x, textureLod(tex_depth, u + (yaxis ? float2(0.0,0.666*su) : float2(0.666*su,0.0)), 0).x), textureLod(tex_depth, u + (yaxis ? float2(0.0,su) : float2(su,0.0)), 0).x);
 	float parallax = (w_h_height.w+MaxSeparation) - min(MaxSeparation/(0.5+minDepth*(1.0/ZPD-0.5)), (w_h_height.w+MaxSeparation));
 	if(!l)
 		parallax = -parallax;
 	if(yaxis)
 		parallax = -parallax;
-	float3 col = textureLod(Texture1, u + (yaxis ? float2(0.0,parallax) : float2(parallax,0.0)), 0).xyz;
+	float3 col = textureLod(tex_fb_filtered, u + (yaxis ? float2(0.0,parallax) : float2(parallax,0.0)), 0).xyz;
 	//if(!aa)
 	//	return float4(col, 1.0); // otherwise blend with 'missing' scanline
 	float2 aaoffs = sidebyside ? float2(w_h_height.x,0.0) : float2(0.0,w_h_height.y);
-	minDepth = min(min(textureLod(Texture4, u + (yaxis ? float2(0.0,0.5*su) : float2(0.5*su,0.0)) + aaoffs, 0).x, textureLod(Texture4, u + (yaxis ? float2(0.0,0.666*su) : float2(0.666*su,0.0)) + aaoffs, 0).x), textureLod(Texture4, u + (yaxis ? float2(0.0,su) : float2(su,0.0)) + aaoffs, 0).x);
+	minDepth = min(min(textureLod(tex_depth, u + (yaxis ? float2(0.0,0.5*su) : float2(0.5*su,0.0)) + aaoffs, 0).x, textureLod(tex_depth, u + (yaxis ? float2(0.0,0.666*su) : float2(0.666*su,0.0)) + aaoffs, 0).x), textureLod(tex_depth, u + (yaxis ? float2(0.0,su) : float2(su,0.0)) + aaoffs, 0).x);
 	parallax = (w_h_height.w+MaxSeparation) - min(MaxSeparation/(0.5+minDepth*(1.0/ZPD-0.5)), (w_h_height.w+MaxSeparation));
 	if(!l)
 		parallax = -parallax;
 	if(yaxis)
 		parallax = -parallax;
-	color = float4((col + textureLod(Texture1, u + (yaxis ? float2(0.0,parallax) : float2(parallax,0.0)) + aaoffs, 0).xyz)*0.5, 1.0);
+	color = float4((col + textureLod(tex_fb_filtered, u + (yaxis ? float2(0.0,parallax) : float2(parallax,0.0)) + aaoffs, 0).xyz)*0.5, 1.0);
 }
 
 ////ps_main_nfaa
@@ -181,14 +181,14 @@ float2 findContrastByLuminance(float2 XYCoord, float filterSpread)
 	float2 upOffset    = float2(0.0, w_h_height.y * filterSpread);
 	float2 rightOffset = float2(w_h_height.x * filterSpread, 0.0);
 
-	float topHeight         = GetLuminance(textureLod(Texture1, XYCoord +               upOffset, 0).rgb);
-	float bottomHeight      = GetLuminance(textureLod(Texture1, XYCoord -               upOffset, 0).rgb);
-	float rightHeight       = GetLuminance(textureLod(Texture1, XYCoord + rightOffset           , 0).rgb);
-	float leftHeight        = GetLuminance(textureLod(Texture1, XYCoord - rightOffset           , 0).rgb);
-	float leftTopHeight     = GetLuminance(textureLod(Texture1, XYCoord - rightOffset + upOffset, 0).rgb);
-	float leftBottomHeight  = GetLuminance(textureLod(Texture1, XYCoord - rightOffset - upOffset, 0).rgb);
-	float rightBottomHeight = GetLuminance(textureLod(Texture1, XYCoord + rightOffset + upOffset, 0).rgb);
-	float rightTopHeight    = GetLuminance(textureLod(Texture1, XYCoord + rightOffset - upOffset, 0).rgb);
+	float topHeight         = GetLuminance(textureLod(tex_fb_filtered, XYCoord +               upOffset, 0).rgb);
+	float bottomHeight      = GetLuminance(textureLod(tex_fb_filtered, XYCoord -               upOffset, 0).rgb);
+	float rightHeight       = GetLuminance(textureLod(tex_fb_filtered, XYCoord + rightOffset           , 0).rgb);
+	float leftHeight        = GetLuminance(textureLod(tex_fb_filtered, XYCoord - rightOffset           , 0).rgb);
+	float leftTopHeight     = GetLuminance(textureLod(tex_fb_filtered, XYCoord - rightOffset + upOffset, 0).rgb);
+	float leftBottomHeight  = GetLuminance(textureLod(tex_fb_filtered, XYCoord - rightOffset - upOffset, 0).rgb);
+	float rightBottomHeight = GetLuminance(textureLod(tex_fb_filtered, XYCoord + rightOffset + upOffset, 0).rgb);
+	float rightTopHeight    = GetLuminance(textureLod(tex_fb_filtered, XYCoord + rightOffset - upOffset, 0).rgb);
 
 #ifdef NFAA_EDGE_DETECTION_VARIANT
 	float sum0 = rightTopHeight    + bottomHeight + leftTopHeight;
@@ -213,14 +213,14 @@ float2 findContrastByColor(float2 XYCoord, float filterSpread)
 	float2 upOffset    = float2(0.0, w_h_height.y * filterSpread);
 	float2 rightOffset = float2(w_h_height.x * filterSpread, 0.0);
 
-	float3 topHeight         = textureLod(Texture1, XYCoord +               upOffset, 0).rgb;
-	float3 bottomHeight      = textureLod(Texture1, XYCoord -               upOffset, 0).rgb;
-	float3 rightHeight       = textureLod(Texture1, XYCoord + rightOffset           , 0).rgb;
-	float3 leftHeight        = textureLod(Texture1, XYCoord - rightOffset           , 0).rgb;
-	float3 leftTopHeight     = textureLod(Texture1, XYCoord - rightOffset + upOffset, 0).rgb;
-	float3 leftBottomHeight  = textureLod(Texture1, XYCoord - rightOffset - upOffset, 0).rgb;
-	float3 rightBottomHeight = textureLod(Texture1, XYCoord + rightOffset + upOffset, 0).rgb;
-	float3 rightTopHeight    = textureLod(Texture1, XYCoord + rightOffset - upOffset, 0).rgb;
+	float3 topHeight         = textureLod(tex_fb_filtered, XYCoord +               upOffset, 0).rgb;
+	float3 bottomHeight      = textureLod(tex_fb_filtered, XYCoord -               upOffset, 0).rgb;
+	float3 rightHeight       = textureLod(tex_fb_filtered, XYCoord + rightOffset           , 0).rgb;
+	float3 leftHeight        = textureLod(tex_fb_filtered, XYCoord - rightOffset           , 0).rgb;
+	float3 leftTopHeight     = textureLod(tex_fb_filtered, XYCoord - rightOffset + upOffset, 0).rgb;
+	float3 leftBottomHeight  = textureLod(tex_fb_filtered, XYCoord - rightOffset - upOffset, 0).rgb;
+	float3 rightBottomHeight = textureLod(tex_fb_filtered, XYCoord + rightOffset + upOffset, 0).rgb;
+	float3 rightTopHeight    = textureLod(tex_fb_filtered, XYCoord + rightOffset - upOffset, 0).rgb;
 
 #ifdef NFAA_EDGE_DETECTION_VARIANT
 	float sum0 = rightTopHeight    + bottomHeight + leftTopHeight;
@@ -256,8 +256,8 @@ void main()
 
 	float2 u = tex0 + w_h_height.xy*0.5;
 
-	float3 Scene0 = textureLod(Texture1, u, 0).rgb;
-	float depth0 = textureLod(Texture4, u, 0).x;
+	float3 Scene0 = textureLod(tex_fb_filtered, u, 0).rgb;
+	float depth0 = textureLod(tex_depth, u, 0).x;
 	if ((w_h_height.w == 1.0) && ((depth0 == 1.0) || (depth0 == 0.0))) // early out if depth too large (=BG) or too small (=DMD,etc)
 			color = float4(Scene0, 1.0);
 	else {
@@ -278,14 +278,14 @@ void main()
 
 		float2 Normal = Vectors * (w_h_height.xy /* * 2.0*/);
 
-		float3 Scene1 = textureLod(Texture1, u + Normal, 0).rgb;
-		float3 Scene2 = textureLod(Texture1, u - Normal, 0).rgb;
+		float3 Scene1 = textureLod(tex_fb_filtered, u + Normal, 0).rgb;
+		float3 Scene2 = textureLod(tex_fb_filtered, u - Normal, 0).rgb;
 #if defined(NFAA_VARIANT) || defined(NFAA_VARIANT2)
-		float3 Scene3 = textureLod(Texture1, u + float2(Normal.x, -Normal.y)*0.5, 0).rgb;
-		float3 Scene4 = textureLod(Texture1, u - float2(Normal.x, -Normal.y)*0.5, 0).rgb;
+		float3 Scene3 = textureLod(tex_fb_filtered, u + float2(Normal.x, -Normal.y)*0.5, 0).rgb;
+		float3 Scene4 = textureLod(tex_fb_filtered, u - float2(Normal.x, -Normal.y)*0.5, 0).rgb;
 #else
-		float3 Scene3 = textureLod(Texture1, u + float2(Normal.x, -Normal.y), 0).rgb;
-		float3 Scene4 = textureLod(Texture1, u - float2(Normal.x, -Normal.y), 0).rgb;
+		float3 Scene3 = textureLod(tex_fb_filtered, u + float2(Normal.x, -Normal.y), 0).rgb;
+		float3 Scene4 = textureLod(tex_fb_filtered, u - float2(Normal.x, -Normal.y), 0).rgb;
 #endif
 
 #ifdef NFAA_TEST_MODE // debug
@@ -302,12 +302,12 @@ void main()
 
 float3 sampleOffset(float2 u, float2 pixelOffset )
 {
-   return textureLod(Texture1, u + pixelOffset * w_h_height.xy, 0).xyz;
+   return textureLod(tex_fb_filtered, u + pixelOffset * w_h_height.xy, 0).xyz;
 }
 
 float4 sampleOffseta(float2 u, float2 pixelOffset )
 {
-   return textureLod(Texture1, u + pixelOffset * w_h_height.xy, 0);
+   return textureLod(tex_fb_filtered, u + pixelOffset * w_h_height.xy, 0);
 }
 
 float avg(float3 l)
@@ -349,7 +349,7 @@ void main()
 
    float4 sampleCenter = sampleOffseta(u, float2( 0.0,  0.0) );
    
-	float depth0 = textureLod(Texture4, u, 0).x;
+	float depth0 = textureLod(tex_depth, u, 0).x;
 	if ((w_h_height.w == 1.0) && ((depth0 == 1.0) || (depth0 == 0.0))) // early out if depth too large (=BG) or too small (=DMD,etc)
 			color = float4(sampleCenter.xyz, 1.0);
 	else {
@@ -463,21 +463,21 @@ void main()
 {
 	float2 u = tex0 + w_h_height.xy*0.5;
 
-	float3 rMc = textureLod(Texture1, u, 0).xyz;
-	float depth0 = textureLod(Texture4, u, 0).x;
+	float3 rMc = textureLod(tex_fb_unfiltered, u, 0).xyz;
+	float depth0 = textureLod(tex_depth, u, 0).x;
 	if ((w_h_height.w == 1.0) && ((depth0 == 1.0) || (depth0 == 0.0))) // early out if depth too large (=BG) or too small (=DMD,etc)
 			color = float4(rMc, 1.0);
 	else {
 		float2 offs = w_h_height.xy;
-		float rNW = luma(textureLod(Texture1, u - offs, 0).xyz);
-		float rN = luma(textureLod(Texture1, u - float2(0.0,offs.y), 0).xyz);
-		float rNE = luma(textureLod(Texture1, u - float2(-offs.x,offs.y), 0).xyz);
-		float rW = luma(textureLod(Texture1, u - float2(offs.x,0.0), 0).xyz);
+		float rNW = luma(textureLod(tex_fb_unfiltered, u - offs, 0).xyz);
+		float rN = luma(textureLod(tex_fb_unfiltered, u - float2(0.0,offs.y), 0).xyz);
+		float rNE = luma(textureLod(tex_fb_unfiltered, u - float2(-offs.x,offs.y), 0).xyz);
+		float rW = luma(textureLod(tex_fb_unfiltered, u - float2(offs.x,0.0), 0).xyz);
 		float rM = luma(rMc);
-		float rE = luma(textureLod(Texture1, u + float2(offs.x,0.0), 0).xyz);
-		float rSW = luma(textureLod(Texture1, u + float2(-offs.x,offs.y), 0).xyz);
-		float rS = luma(textureLod(Texture1, u + float2(0.0,offs.y), 0).xyz);
-		float rSE = luma(textureLod(Texture1, u + offs, 0).xyz);
+		float rE = luma(textureLod(tex_fb_unfiltered, u + float2(offs.x,0.0), 0).xyz);
+		float rSW = luma(textureLod(tex_fb_unfiltered, u + float2(-offs.x,offs.y), 0).xyz);
+		float rS = luma(textureLod(tex_fb_unfiltered, u + float2(0.0,offs.y), 0).xyz);
+		float rSE = luma(textureLod(tex_fb_unfiltered, u + offs, 0).xyz);
 		float rMrN = rM+rN;
 		float lumaNW = rMrN+rNW+rW;
 		float lumaNE = rMrN+rNE+rE;
@@ -497,8 +497,8 @@ void main()
 		float2 dir = float2(SWSE - NWNE, (lumaNW + lumaSW) - (lumaNE + lumaSE));
 		float temp = 1.0/(min(abs(dir.x), abs(dir.y)) + max((NWNE + SWSE)*0.03125, 0.0078125)); //!! tweak?
 		dir = clamp(dir*temp, float2(-8.0), float2(8.0)) * offs; //!! tweak?
-		float3 rgbA = 0.5 * (textureLod(Texture1, u-dir*(0.5/3.0), 0).xyz + textureLod(Texture1, u+dir*(0.5/3.0), 0).xyz);
-		float3 rgbB = 0.5 * rgbA + 0.25 * (textureLod(Texture1, u-dir*0.5, 0).xyz + textureLod(Texture1, u+dir*0.5, 0).xyz);
+		float3 rgbA = 0.5 * (textureLod(tex_fb_filtered, u-dir*(0.5/3.0), 0).xyz + textureLod(tex_fb_filtered, u+dir*(0.5/3.0), 0).xyz);
+		float3 rgbB = 0.5 * rgbA + 0.25 * (textureLod(tex_fb_filtered, u-dir*0.5, 0).xyz + textureLod(tex_fb_filtered, u+dir*0.5, 0).xyz);
 		float lumaB = luma(rgbB);
 		color = float4(((lumaB < lumaMin) || (lumaB > lumaMax)) ? rgbA : rgbB, 1.0);
 	}
@@ -518,21 +518,21 @@ void main()
 {
 	float2 u = tex0 + w_h_height.xy*0.5;
 
-	float3 rgbyM = textureLod(Texture1, u, 0).xyz;
-	float depth0 = textureLod(Texture4, u, 0).x;
+	float3 rgbyM = textureLod(tex_fb_unfiltered, u, 0).xyz;
+	float depth0 = textureLod(tex_depth, u, 0).x;
 	if ((w_h_height.w == 1.0) && ((depth0 == 1.0) || (depth0 == 0.0))) // early out if depth too large (=BG) or too small (=DMD,etc)
 			color = float4(rgbyM, 1.0);
 	else {
 		float2 offs = w_h_height.xy;
-		float lumaNW = luma(textureLod(Texture1, u - offs, 0).xyz);
-		float lumaN = luma(textureLod(Texture1, u - float2(0.0,offs.y), 0).xyz);
-		float lumaNE = luma(textureLod(Texture1, u - float2(-offs.x,offs.y), 0).xyz);
-		float lumaW = luma(textureLod(Texture1, u - float2(offs.x,0.0), 0).xyz);
+		float lumaNW = luma(textureLod(tex_fb_unfiltered, u - offs, 0).xyz);
+		float lumaN = luma(textureLod(tex_fb_unfiltered, u - float2(0.0,offs.y), 0).xyz);
+		float lumaNE = luma(textureLod(tex_fb_unfiltered, u - float2(-offs.x,offs.y), 0).xyz);
+		float lumaW = luma(textureLod(tex_fb_unfiltered, u - float2(offs.x,0.0), 0).xyz);
 		float lumaM = luma(rgbyM);
-		float lumaE = luma(textureLod(Texture1, u + float2(offs.x,0.0), 0).xyz);
-		float lumaSW = luma(textureLod(Texture1, u + float2(-offs.x,offs.y), 0).xyz);
-		float lumaS = luma(textureLod(Texture1, u + float2(0.0,offs.y), 0).xyz);
-		float lumaSE = luma(textureLod(Texture1, u + offs, 0).xyz);
+		float lumaE = luma(textureLod(tex_fb_unfiltered, u + float2(offs.x,0.0), 0).xyz);
+		float lumaSW = luma(textureLod(tex_fb_unfiltered, u + float2(-offs.x,offs.y), 0).xyz);
+		float lumaS = luma(textureLod(tex_fb_unfiltered, u + float2(0.0,offs.y), 0).xyz);
+		float lumaSE = luma(textureLod(tex_fb_unfiltered, u + offs, 0).xyz);
 		float maxSM = max(lumaS, lumaM);
 		float minSM = min(lumaS, lumaM);
 		float maxESM = max(lumaE, maxSM);
@@ -590,9 +590,9 @@ void main()
 			float2 posN = float2(posB.x - offNP.x * FXAA_QUALITY__P0, posB.y - offNP.y * FXAA_QUALITY__P0);
 			float2 posP = float2(posB.x + offNP.x * FXAA_QUALITY__P0, posB.y + offNP.y * FXAA_QUALITY__P0);
 			float subpixD = -2.0 * subpixC + 3.0;
-			float lumaEndN = luma(textureLod(Texture1, posN, 0).xyz);
+			float lumaEndN = luma(textureLod(tex_fb_filtered, posN, 0).xyz);
 			float subpixE = subpixC * subpixC;
-			float lumaEndP = luma(textureLod(Texture1, posP, 0).xyz);
+			float lumaEndP = luma(textureLod(tex_fb_filtered, posP, 0).xyz);
 			if(!pairN) lumaNN = lumaSS;
 			float gradientScaled = gradient * (1.0/4.0);
 			float lumaMM = lumaM - lumaNN * 0.5;
@@ -608,8 +608,8 @@ void main()
 			if(!doneP) posP.x += offNP.x * FXAA_QUALITY__P1;
 			if(!doneP) posP.y += offNP.y * FXAA_QUALITY__P1;
 			if(doneNP) {
-				if(!doneN) lumaEndN = luma(textureLod(Texture1, posN.xy, 0).xyz);
-				if(!doneP) lumaEndP = luma(textureLod(Texture1, posP.xy, 0).xyz);
+				if(!doneN) lumaEndN = luma(textureLod(tex_fb_filtered, posN.xy, 0).xyz);
+				if(!doneP) lumaEndP = luma(textureLod(tex_fb_filtered, posP.xy, 0).xyz);
 				if(!doneN) lumaEndN = lumaEndN - lumaNN * 0.5;
 				if(!doneP) lumaEndP = lumaEndP - lumaNN * 0.5;
 				doneN = abs(lumaEndN) >= gradientScaled;
@@ -638,7 +638,7 @@ void main()
 			float pl = pixelOffsetSubpix * lengthSign;
 			if(horzSpan) un.y += pl;
 			else un.x += pl;
-			color = float4(textureLod(Texture1, un, 0).xyz, 1.0f);
+			color = float4(textureLod(tex_fb_filtered, un, 0).xyz, 1.0f);
 		}
 	}
 }
@@ -670,21 +670,21 @@ void main()
 {
 	float2 u = tex0 + w_h_height.xy*0.5;
 
-	float3 rgbyM = textureLod(Texture1, u, 0).xyz;
-	float depth0 = textureLod(Texture4, u, 0).x;
+	float3 rgbyM = textureLod(tex_fb_unfiltered, u, 0).xyz;
+	float depth0 = textureLod(tex_depth, u, 0).x;
 	if ((w_h_height.w == 1.0) && ((depth0 == 1.0) || (depth0 == 0.0))) // early out if depth too large (=BG) or too small (=DMD,etc)
 			color = float4(rgbyM, 1.0);
 	else {
 		float2 offs = w_h_height.xy;
-		float lumaNW = luma(textureLod(Texture1, u - offs, 0).xyz);
-		float lumaN = luma(textureLod(Texture1, u - float2(0.0,offs.y), 0).xyz);
-		float lumaNE = luma(textureLod(Texture1, u - float2(-offs.x,offs.y), 0).xyz);
-		float lumaW = luma(textureLod(Texture1, u - float2(offs.x,0.0), 0).xyz);
+		float lumaNW = luma(textureLod(tex_fb_unfiltered, u - offs, 0).xyz);
+		float lumaN = luma(textureLod(tex_fb_unfiltered, u - float2(0.0,offs.y), 0).xyz);
+		float lumaNE = luma(textureLod(tex_fb_unfiltered, u - float2(-offs.x,offs.y), 0).xyz);
+		float lumaW = luma(textureLod(tex_fb_unfiltered, u - float2(offs.x,0.0), 0).xyz);
 		float lumaM = luma(rgbyM);
-		float lumaE = luma(textureLod(Texture1, u + float2(offs.x,0.0), 0).xyz);
-		float lumaSW = luma(textureLod(Texture1, u + float2(-offs.x,offs.y), 0).xyz);
-		float lumaS = luma(textureLod(Texture1, u + float2(0.0,offs.y), 0).xyz);
-		float lumaSE = luma(textureLod(Texture1, u + offs, 0).xyz);
+		float lumaE = luma(textureLod(tex_fb_unfiltered, u + float2(offs.x,0.0), 0).xyz);
+		float lumaSW = luma(textureLod(tex_fb_unfiltered, u + float2(-offs.x,offs.y), 0).xyz);
+		float lumaS = luma(textureLod(tex_fb_unfiltered, u + float2(0.0,offs.y), 0).xyz);
+		float lumaSE = luma(textureLod(tex_fb_unfiltered, u + offs, 0).xyz);
 		float maxSM = max(lumaS, lumaM);
 		float minSM = min(lumaS, lumaM);
 		float maxESM = max(lumaE, maxSM);
@@ -742,9 +742,9 @@ void main()
 			float2 posN = float2(posB.x - offNP.x * FXAA_QUALITY__P0, posB.y - offNP.y * FXAA_QUALITY__P0);
 			float2 posP = float2(posB.x + offNP.x * FXAA_QUALITY__P0, posB.y + offNP.y * FXAA_QUALITY__P0);
 			float subpixD = -2.0 * subpixC + 3.0;
-			float lumaEndN = luma(textureLod(Texture1, posN, 0).xyz);
+			float lumaEndN = luma(textureLod(tex_fb_filtered, posN, 0).xyz);
 			float subpixE = subpixC * subpixC;
-			float lumaEndP = luma(textureLod(Texture1, posP, 0).xyz);
+			float lumaEndP = luma(textureLod(tex_fb_filtered, posP, 0).xyz);
 			if(!pairN) lumaNN = lumaSS;
 			float gradientScaled = gradient * (1.0/4.0);
 			float lumaMM = lumaM - lumaNN * 0.5;
@@ -760,8 +760,8 @@ void main()
 			if(!doneP) posP.x += offNP.x * FXAA_QUALITY__P1;
 			if(!doneP) posP.y += offNP.y * FXAA_QUALITY__P1;
 			if(doneNP) {
-				if(!doneN) lumaEndN = luma(textureLod(Texture1, posN.xy, 0).xyz);
-				if(!doneP) lumaEndP = luma(textureLod(Texture1, posP.xy, 0).xyz);
+				if(!doneN) lumaEndN = luma(textureLod(tex_fb_filtered, posN.xy, 0).xyz);
+				if(!doneP) lumaEndP = luma(textureLod(tex_fb_filtered, posP.xy, 0).xyz);
 				if(!doneN) lumaEndN = lumaEndN - lumaNN * 0.5;
 				if(!doneP) lumaEndP = lumaEndP - lumaNN * 0.5;
 				doneN = abs(lumaEndN) >= gradientScaled;
@@ -775,8 +775,8 @@ void main()
 				//
 
 				if(doneNP) {
-				if(!doneN) lumaEndN = luma(textureLod(Texture1, posN.xy, 0).xyz);
-				if(!doneP) lumaEndP = luma(textureLod(Texture1, posP.xy, 0).xyz);
+				if(!doneN) lumaEndN = luma(textureLod(tex_fb_filtered, posN.xy, 0).xyz);
+				if(!doneP) lumaEndP = luma(textureLod(tex_fb_filtered, posP.xy, 0).xyz);
 				if(!doneN) lumaEndN = lumaEndN - lumaNN * 0.5;
 				if(!doneP) lumaEndP = lumaEndP - lumaNN * 0.5;
 				doneN = abs(lumaEndN) >= gradientScaled;
@@ -788,8 +788,8 @@ void main()
 				if(!doneP) posP.y += offNP.y * FXAA_QUALITY__P3;
 
 				if(doneNP) {
-				if(!doneN) lumaEndN = luma(textureLod(Texture1, posN.xy, 0).xyz);
-				if(!doneP) lumaEndP = luma(textureLod(Texture1, posP.xy, 0).xyz);
+				if(!doneN) lumaEndN = luma(textureLod(tex_fb_filtered, posN.xy, 0).xyz);
+				if(!doneP) lumaEndP = luma(textureLod(tex_fb_filtered, posP.xy, 0).xyz);
 				if(!doneN) lumaEndN = lumaEndN - lumaNN * 0.5;
 				if(!doneP) lumaEndP = lumaEndP - lumaNN * 0.5;
 				doneN = abs(lumaEndN) >= gradientScaled;
@@ -801,8 +801,8 @@ void main()
 				if(!doneP) posP.y += offNP.y * FXAA_QUALITY__P4;
 
 				if(doneNP) {
-				if(!doneN) lumaEndN = luma(textureLod(Texture1, posN.xy, 0).xyz);
-				if(!doneP) lumaEndP = luma(textureLod(Texture1, posP.xy, 0).xyz);
+				if(!doneN) lumaEndN = luma(textureLod(tex_fb_filtered, posN.xy, 0).xyz);
+				if(!doneP) lumaEndP = luma(textureLod(tex_fb_filtered, posP.xy, 0).xyz);
 				if(!doneN) lumaEndN = lumaEndN - lumaNN * 0.5;
 				if(!doneP) lumaEndP = lumaEndP - lumaNN * 0.5;
 				doneN = abs(lumaEndN) >= gradientScaled;
@@ -814,8 +814,8 @@ void main()
 				if(!doneP) posP.y += offNP.y * FXAA_QUALITY__P5;
 
 				if(doneNP) {
-				if(!doneN) lumaEndN = luma(textureLod(Texture1, posN.xy, 0).xyz);
-				if(!doneP) lumaEndP = luma(textureLod(Texture1, posP.xy, 0).xyz);
+				if(!doneN) lumaEndN = luma(textureLod(tex_fb_filtered, posN.xy, 0).xyz);
+				if(!doneP) lumaEndP = luma(textureLod(tex_fb_filtered, posP.xy, 0).xyz);
 				if(!doneN) lumaEndN = lumaEndN - lumaNN * 0.5;
 				if(!doneP) lumaEndP = lumaEndP - lumaNN * 0.5;
 				doneN = abs(lumaEndN) >= gradientScaled;
@@ -827,8 +827,8 @@ void main()
 				if(!doneP) posP.y += offNP.y * FXAA_QUALITY__P6;
 
 				if(doneNP) {
-				if(!doneN) lumaEndN = luma(textureLod(Texture1, posN.xy, 0).xyz);
-				if(!doneP) lumaEndP = luma(textureLod(Texture1, posP.xy, 0).xyz);
+				if(!doneN) lumaEndN = luma(textureLod(tex_fb_filtered, posN.xy, 0).xyz);
+				if(!doneP) lumaEndP = luma(textureLod(tex_fb_filtered, posP.xy, 0).xyz);
 				if(!doneN) lumaEndN = lumaEndN - lumaNN * 0.5;
 				if(!doneP) lumaEndP = lumaEndP - lumaNN * 0.5;
 				doneN = abs(lumaEndN) >= gradientScaled;
@@ -840,8 +840,8 @@ void main()
 				if(!doneP) posP.y += offNP.y * FXAA_QUALITY__P7;
 
 				if(doneNP) {
-				if(!doneN) lumaEndN = luma(textureLod(Texture1, posN.xy, 0).xyz);
-				if(!doneP) lumaEndP = luma(textureLod(Texture1, posP.xy, 0).xyz);
+				if(!doneN) lumaEndN = luma(textureLod(tex_fb_filtered, posN.xy, 0).xyz);
+				if(!doneP) lumaEndP = luma(textureLod(tex_fb_filtered, posP.xy, 0).xyz);
 				if(!doneN) lumaEndN = lumaEndN - lumaNN * 0.5;
 				if(!doneP) lumaEndP = lumaEndP - lumaNN * 0.5;
 				doneN = abs(lumaEndN) >= gradientScaled;
@@ -853,8 +853,8 @@ void main()
 				if(!doneP) posP.y += offNP.y * FXAA_QUALITY__P8;
 
 				if(doneNP) {
-				if(!doneN) lumaEndN = luma(textureLod(Texture1, posN.xy, 0).xyz);
-				if(!doneP) lumaEndP = luma(textureLod(Texture1, posP.xy, 0).xyz);
+				if(!doneN) lumaEndN = luma(textureLod(tex_fb_filtered, posN.xy, 0).xyz);
+				if(!doneP) lumaEndP = luma(textureLod(tex_fb_filtered, posP.xy, 0).xyz);
 				if(!doneN) lumaEndN = lumaEndN - lumaNN * 0.5;
 				if(!doneP) lumaEndP = lumaEndP - lumaNN * 0.5;
 				doneN = abs(lumaEndN) >= gradientScaled;
@@ -866,8 +866,8 @@ void main()
 				if(!doneP) posP.y += offNP.y * FXAA_QUALITY__P9;
 
 				if(doneNP) {
-				if(!doneN) lumaEndN = luma(textureLod(Texture1, posN.xy, 0).xyz);
-				if(!doneP) lumaEndP = luma(textureLod(Texture1, posP.xy, 0).xyz);
+				if(!doneN) lumaEndN = luma(textureLod(tex_fb_filtered, posN.xy, 0).xyz);
+				if(!doneP) lumaEndP = luma(textureLod(tex_fb_filtered, posP.xy, 0).xyz);
 				if(!doneN) lumaEndN = lumaEndN - lumaNN * 0.5;
 				if(!doneP) lumaEndP = lumaEndP - lumaNN * 0.5;
 				doneN = abs(lumaEndN) >= gradientScaled;
@@ -879,8 +879,8 @@ void main()
 				if(!doneP) posP.y += offNP.y * FXAA_QUALITY__P10;
 
 				if(doneNP) {
-				if(!doneN) lumaEndN = luma(textureLod(Texture1, posN.xy, 0).xyz);
-				if(!doneP) lumaEndP = luma(textureLod(Texture1, posP.xy, 0).xyz);
+				if(!doneN) lumaEndN = luma(textureLod(tex_fb_filtered, posN.xy, 0).xyz);
+				if(!doneP) lumaEndP = luma(textureLod(tex_fb_filtered, posP.xy, 0).xyz);
 				if(!doneN) lumaEndN = lumaEndN - lumaNN * 0.5;
 				if(!doneP) lumaEndP = lumaEndP - lumaNN * 0.5;
 				doneN = abs(lumaEndN) >= gradientScaled;
@@ -918,7 +918,7 @@ void main()
 			float pl = pixelOffsetSubpix * lengthSign;
 			if(horzSpan) un.y += pl;
 			else un.x += pl;
-			color = float4(textureLod(Texture1, un, 0).xyz, 1.0f);
+			color = float4(textureLod(tex_fb_filtered, un, 0).xyz, 1.0f);
 		}
 	}
 }

--- a/glshader/FlasherShader.glfx
+++ b/glshader/FlasherShader.glfx
@@ -40,8 +40,8 @@ uniform float4 staticColor_Alpha;
 uniform float4 alphaTestValueAB_filterMode_addBlend; // last one bool
 uniform float4 amount_blend_modulate_vs_add_flasherMode;
 
-uniform sampler2D Texture0; // base texture
-uniform sampler2D Texture1; // second image
+uniform sampler2D tex_flasher_A; // base texture
+uniform sampler2D tex_flasher_B; // second image
 
 in vec2 tex0;
 out vec4 color;
@@ -82,12 +82,12 @@ void main()
 
    if (amount_blend_modulate_vs_add_flasherMode.z < 2.) // Mode 0 & 1
    {
-      pixel1 = texture(Texture0, tex0);
+      pixel1 = texture(tex_flasher_A, tex0);
       stop = (pixel1.a <= alphaTestValueAB_filterMode_addBlend.x);
    }
    if (amount_blend_modulate_vs_add_flasherMode.z == 1.)
    {
-      pixel2 = texture(Texture1, tex0);
+      pixel2 = texture(tex_flasher_B, tex0);
       stop = (stop || pixel2.a <= alphaTestValueAB_filterMode_addBlend.y);
    }
 
@@ -95,7 +95,7 @@ void main()
 
    float4 result = staticColor_Alpha; // Mode 2 wires this through
 
-   if (amount_blend_modulate_vs_add_flasherMode.z == 0.) // Mode 0 mods it by Texture
+   if (amount_blend_modulate_vs_add_flasherMode.z == 0.) // Mode 0 mods it by texture
    {
       result *= pixel1;
       result.a = clamp(result.a, 0.0, 200.0); // Need to clamp here or we get some saturation artifacts on some tables

--- a/glshader/Material.fxh
+++ b/glshader/Material.fxh
@@ -203,7 +203,7 @@ float3 lightLoop(const float3 pos, float3 N, const float3 V, float3 diffuse, flo
          float mipLevel = min(textureQueryLod(tex_env, Ruv).y, textureQueryLevels(tex_env)/2);
          if (mipLevel < 4.0)
             mipLevel = 4.0;
-         colorMip = textureLod(Texture1, Ruv, mipLevel);
+         colorMip = textureLod(tex_env, Ruv, mipLevel);
       }
          
       vec3 envTex = colorMip.rgb;

--- a/glshader/SMAA.glfx
+++ b/glshader/SMAA.glfx
@@ -66,7 +66,9 @@ uniform vec4 w_h_height;
 
 ////FRAGMENT
 
-uniform sampler2D Texture1;
+uniform sampler2D colorTex;
+uniform sampler2D colorGammaTex;
+
 uniform sampler2D edgesTex2D;
 uniform sampler2D blendTex2D;
 
@@ -128,7 +130,7 @@ in vec4[3] offset;
 
 void main()
 {
-    color = vec4(SMAAColorEdgeDetectionPS(texcoord, offset, Texture1), 0.0, 0.0);
+    color = vec4(SMAAColorEdgeDetectionPS(texcoord, offset, colorGammaTex), 0.0, 0.0);
 }
 
 ////GLSL_SMAABlendingWeightCalculationPS
@@ -149,7 +151,7 @@ in vec4 offset;
 
 void main()
 {
-    color = SMAANeighborhoodBlendingPS(texcoord, offset, Texture1, blendTex2D);
+    color = SMAANeighborhoodBlendingPS(texcoord, offset, colorTex, blendTex2D);
 }
 
 ////TECHNIQUES

--- a/glshader/StereoShader.glfx
+++ b/glshader/StereoShader.glfx
@@ -106,7 +106,7 @@ out vec2 tex0;
 
 ////FRAGMENT
 
-uniform sampler2D  tex_stereo_fb; // Render buffer with left eye on the top half, and right eye on the bottom half
+uniform sampler2D  tex_stereo_fb; // Render buffer with the 2 eyes side by side for anaglyph, top/bottom for interlaced
 
 in vec2 tex0;
 

--- a/glshader/StereoShader.glfx
+++ b/glshader/StereoShader.glfx
@@ -106,7 +106,7 @@ out vec2 tex0;
 
 ////FRAGMENT
 
-uniform sampler2D  Texture0; // Render buffer with left eye on the top half, and right eye on the bottom half
+uniform sampler2D  tex_stereo_fb; // Render buffer with left eye on the top half, and right eye on the bottom half
 
 in vec2 tex0;
 
@@ -124,14 +124,14 @@ void main()
 
 void main()
 {
-   color = tex2D(Texture0, vec2(tex0.x,0.5*tex0.y + ((frac(gl_FragCoord.y*0.5) < 0.5) ? 0.0 : 0.5)));
+   color = tex2D(tex_stereo_fb, vec2(tex0.x,0.5*tex0.y + ((frac(gl_FragCoord.y*0.5) < 0.5) ? 0.0 : 0.5)));
 }
 
 ////ps_main_flipped_int
 
 void main()
 {
-   color = tex2D(Texture0, vec2(tex0.x,0.5*tex0.y + ((frac(gl_FragCoord.y*0.5) < 0.5) ? 0.5 : 0.0)));
+   color = tex2D(tex_stereo_fb, vec2(tex0.x,0.5*tex0.y + ((frac(gl_FragCoord.y*0.5) < 0.5) ? 0.5 : 0.0)));
 }
 
 ////vs_main_amd
@@ -156,15 +156,15 @@ void main()
    } else {
       x = tex0.x*0.5+0.5;
    }
-   color = tex2D(Texture0, vec2(x,tex0.y));
+   color = tex2D(tex_stereo_fb, vec2(x,tex0.y));
 }
 
 ////ps_main_stereo_anaglyph
 
 void main()
 {
-	const float3 lcol = tex2D(Texture0, vec2(0.5*tex0.x,tex0.y)).rgb;
-	const float3 rcol = tex2D(Texture0, vec2(0.5*tex0.x+0.5,tex0.y)).rgb;
+	const float3 lcol = tex2D(tex_stereo_fb, vec2(0.5*tex0.x,tex0.y)).rgb;
+	const float3 rcol = tex2D(tex_stereo_fb, vec2(0.5*tex0.x+0.5,tex0.y)).rgb;
 	const float3 l = (ms_zpd_ya_td.w > 11.0) ? rcol : lcol; // > 10.0 means: flip the eye color
 	const float3 r = (ms_zpd_ya_td.w > 11.0) ? lcol : rcol; // > 10.0 means: flip the eye color
 	color = float4(anaglyph(l, r), 1.0);

--- a/hittarget.cpp
+++ b/hittarget.cpp
@@ -707,7 +707,7 @@ void HitTarget::RenderObject()
    if (pin)
    {
       pd3dDevice->basicShader->SetTechniqueMetal(SHADER_TECHNIQUE_basic_with_texture, mat->m_bIsMetal);
-      pd3dDevice->basicShader->SetTexture(SHADER_Texture0, pin, TextureFilter::TEXTURE_MODE_TRILINEAR, false, false, false);
+      pd3dDevice->basicShader->SetTexture(SHADER_tex_base_color, pin, TextureFilter::TEXTURE_MODE_TRILINEAR, false, false, false);
       pd3dDevice->basicShader->SetAlphaTestValue(pin->m_alphaTestValue * (float)(1.0 / 255.0));
 
       //g_pplayer->m_pin3d.SetPrimaryTextureFilter(0, TEXTURE_MODE_TRILINEAR);

--- a/hittarget.cpp
+++ b/hittarget.cpp
@@ -718,7 +718,7 @@ void HitTarget::RenderObject()
       pd3dDevice->basicShader->SetTechniqueMetal(SHADER_TECHNIQUE_basic_without_texture, mat->m_bIsMetal);
 
    // draw the mesh
-   pd3dDevice->basicShader->Begin(0);
+   pd3dDevice->basicShader->Begin();
    pd3dDevice->DrawIndexedPrimitiveVB(RenderDevice::TRIANGLELIST, MY_D3DFVF_NOTEX2_VERTEX, m_vertexBuffer, 0, m_numVertices, m_indexBuffer, 0, m_numIndices);
    pd3dDevice->basicShader->End();
 
@@ -726,7 +726,7 @@ void HitTarget::RenderObject()
    if (mat->m_bOpacityActive)
    {
       pd3dDevice->SetRenderStateCulling(RenderDevice::CULL_CCW);
-      pd3dDevice->basicShader->Begin(0);
+      pd3dDevice->basicShader->Begin();
       pd3dDevice->DrawIndexedPrimitiveVB(RenderDevice::TRIANGLELIST, MY_D3DFVF_NOTEX2_VERTEX, m_vertexBuffer, 0, m_numVertices, m_indexBuffer, 0, m_numIndices);
       pd3dDevice->basicShader->End();
    }

--- a/kicker.cpp
+++ b/kicker.cpp
@@ -549,7 +549,7 @@ void Kicker::RenderDynamic()
       pd3dDevice->basicShader->SetFloat(SHADER_fKickerScale, m_ptable->m_BG_scalez[m_ptable->m_BG_current_set]);
       pd3dDevice->SetRenderState(RenderDevice::ZFUNC, RenderDevice::Z_ALWAYS);
 
-      pd3dDevice->basicShader->Begin(0);
+      pd3dDevice->basicShader->Begin();
       pd3dDevice->DrawIndexedPrimitiveVB(RenderDevice::TRIANGLELIST, MY_D3DFVF_NOTEX2_VERTEX, m_plateVertexBuffer, 0, kickerPlateNumVertices, m_plateIndexBuffer, 0, kickerPlateNumIndices);
       pd3dDevice->basicShader->End();
 
@@ -566,7 +566,7 @@ void Kicker::RenderDynamic()
       g_pplayer->m_pin3d.EnableAlphaBlend(false);
       pd3dDevice->basicShader->SetAlphaTestValue(-1.0f);
 
-      pd3dDevice->basicShader->Begin(0);
+      pd3dDevice->basicShader->Begin();
       pd3dDevice->DrawIndexedPrimitiveVB(RenderDevice::TRIANGLELIST, MY_D3DFVF_NOTEX2_VERTEX, m_vertexBuffer, 0, m_numVertices, m_indexBuffer, 0, m_numIndices);
       pd3dDevice->basicShader->End();
 

--- a/kicker.cpp
+++ b/kicker.cpp
@@ -558,7 +558,7 @@ void Kicker::RenderDynamic()
       if (m_d.m_kickertype != KickerHoleSimple)
       {
          pd3dDevice->basicShader->SetTechniqueMetal(SHADER_TECHNIQUE_basic_with_texture, mat->m_bIsMetal);
-         pd3dDevice->basicShader->SetTexture(SHADER_Texture0, &m_texture, TextureFilter::TEXTURE_MODE_TRILINEAR, false, false, false);
+         pd3dDevice->basicShader->SetTexture(SHADER_tex_base_color, &m_texture, TextureFilter::TEXTURE_MODE_TRILINEAR, false, false, false);
       }
       else
          pd3dDevice->basicShader->SetTechniqueMetal(SHADER_TECHNIQUE_basic_without_texture, mat->m_bIsMetal);

--- a/kicker.cpp
+++ b/kicker.cpp
@@ -521,10 +521,6 @@ void Kicker::RenderSetup()
 }
 
 
-void Kicker::PreRenderStatic(RenderDevice* pd3dDevice)
-{
-}
-
 void Kicker::SetDefaultPhysics(bool fromMouseClick)
 {
    m_d.m_scatter = fromMouseClick ? LoadValueFloatWithDefault(regKey[RegName::DefaultPropsKicker], "Scatter"s, 0.f) : 0.f;

--- a/kicker.h
+++ b/kicker.h
@@ -76,7 +76,6 @@ public:
    Vertex2D GetCenter() const final;
    void PutCenter(const Vertex2D& pv) final;
 
-   void PreRenderStatic(RenderDevice* pd3dDevice) final;
    void SetDefaultPhysics(bool fromMouseClick) final;
    void ExportMesh(ObjLoader& loader) final;
 

--- a/light.cpp
+++ b/light.cpp
@@ -482,7 +482,7 @@ void Light::RenderDynamic()
       if (offTexel != nullptr)
       {
          pd3dDevice->classicLightShader->SetTechniqueMetal(SHADER_TECHNIQUE_light_with_texture, m_surfaceMaterial->m_bIsMetal);
-         pd3dDevice->classicLightShader->SetTexture(SHADER_Texture0, offTexel, TextureFilter::TEXTURE_MODE_TRILINEAR, true, true, false);
+         pd3dDevice->classicLightShader->SetTexture(SHADER_tex_light_color, offTexel, TextureFilter::TEXTURE_MODE_TRILINEAR, true, true, false);
          // Was: if (m_ptable->m_reflectElementsOnPlayfield && g_pplayer->m_pf_refl && !m_backglass)*/
          // TOTAN and Flintstones inserts break if alpha blending is disabled here.
          // Also see below if changing again

--- a/light.cpp
+++ b/light.cpp
@@ -349,7 +349,7 @@ void Light::RenderBulbMesh()
    pd3dDevice->basicShader->SetTechniqueMetal(SHADER_TECHNIQUE_basic_without_texture, mat.m_bIsMetal);
    pd3dDevice->basicShader->SetMaterial(&mat);
 
-   pd3dDevice->basicShader->Begin(0);
+   pd3dDevice->basicShader->Begin();
    pd3dDevice->DrawIndexedPrimitiveVB(RenderDevice::TRIANGLELIST, MY_D3DFVF_NOTEX2_VERTEX, m_bulbSocketVBuffer, 0, bulbSocketNumVertices, m_bulbSocketIndexBuffer, 0, bulbSocketNumFaces);
    pd3dDevice->basicShader->End();
 
@@ -368,7 +368,7 @@ void Light::RenderBulbMesh()
    pd3dDevice->basicShader->SetTechniqueMetal(SHADER_TECHNIQUE_basic_without_texture, mat.m_bIsMetal);
    pd3dDevice->basicShader->SetMaterial(&mat);
 
-   pd3dDevice->basicShader->Begin(0);
+   pd3dDevice->basicShader->Begin();
    pd3dDevice->DrawIndexedPrimitiveVB(RenderDevice::TRIANGLELIST, MY_D3DFVF_NOTEX2_VERTEX, m_bulbLightVBuffer, 0, bulbLightNumVertices, m_bulbLightIndexBuffer, 0, bulbLightNumFaces);
    pd3dDevice->basicShader->End();
 }
@@ -517,7 +517,7 @@ void Light::RenderDynamic()
          pd3dDevice->lightShader->SetLightColorIntensity(lightColor_intensity);
          pd3dDevice->lightShader->SetFloat(SHADER_blend_modulate_vs_add, 0.00001f); // additive, but avoid full 0, as it disables the blend
 
-         pd3dDevice->lightShader->Begin(0);
+         pd3dDevice->lightShader->Begin();
          pd3dDevice->DrawIndexedPrimitiveVB(RenderDevice::TRIANGLELIST, MY_D3DFVF_NOTEX2_VERTEX, m_bulbLightVBuffer, 0, bulbLightNumVertices, m_bulbLightIndexBuffer, 0, bulbLightNumFaces);
          pd3dDevice->lightShader->End();
       }
@@ -538,14 +538,14 @@ void Light::RenderDynamic()
    if (!m_d.m_BulbLight)
    {
       pd3dDevice->classicLightShader->SetLightColorIntensity(lightColor_intensity);
-      pd3dDevice->classicLightShader->Begin(0);
+      pd3dDevice->classicLightShader->Begin();
    }
    else
    {
       if (g_pplayer->m_current_renderstage == 1)
          lightColor_intensity.w *= m_d.m_transmissionScale;
       pd3dDevice->lightShader->SetLightColorIntensity(lightColor_intensity);
-      pd3dDevice->lightShader->Begin(0);
+      pd3dDevice->lightShader->Begin();
    }
 
    pd3dDevice->DrawIndexedPrimitiveVB(RenderDevice::TRIANGLELIST, (!m_backglass) ? MY_D3DFVF_NOTEX2_VERTEX : MY_D3DTRANSFORMED_NOTEX2_VERTEX, m_customMoverVBuffer, 0, m_customMoverVertexNum, m_customMoverIBuffer, 0, m_customMoverIndexNum);

--- a/pin/hitable.h
+++ b/pin/hitable.h
@@ -8,7 +8,6 @@ public:
    virtual void GetTimers(vector<HitTimer*> &pvht) = 0;
    virtual EventProxyBase *GetEventProxyBase() = 0;
    virtual void EndPlay() = 0;
-   virtual void PreRenderStatic(RenderDevice* pd3dDevice) { } // only used for kickers, due to special playfield cutout
    virtual void RenderStatic() = 0;
    virtual void RenderDynamic() = 0;
    virtual void RenderSetup() = 0;

--- a/pin/player.cpp
+++ b/pin/player.cpp
@@ -1980,8 +1980,6 @@ void Player::RenderMirrorOverlay()
 #endif
 }
 
-#define STB_IMAGE_WRITE_IMPLEMENTATION 
-#include "stb_image_write.h"
 void Player::InitStatic()
 {
    TRACE_FUNCTION();

--- a/pin/player.cpp
+++ b/pin/player.cpp
@@ -3571,12 +3571,12 @@ void Player::DrawBulbLightBuffer()
       {
          const vec4 fb_inv_resolution_05((float)(1.0 / (double)m_pin3d.m_pd3dPrimaryDevice->GetBloomBufferTexture()->GetWidth()), (float)(1.0 / (double)m_pin3d.m_pd3dPrimaryDevice->GetBloomBufferTexture()->GetHeight()), 1.0f, 1.0f);
          {
-            m_pin3d.m_pd3dPrimaryDevice->FBShader->SetTextureNull(SHADER_Texture0);
+            m_pin3d.m_pd3dPrimaryDevice->FBShader->SetTextureNull(SHADER_Texture1);
 
             // switch to 'bloom' temporary output buffer for horizontal phase of gaussian blur
             m_pin3d.m_pd3dPrimaryDevice->GetBloomTmpBufferTexture()->Activate(true);
 
-            m_pin3d.m_pd3dPrimaryDevice->FBShader->SetTexture(SHADER_Texture0, m_pin3d.m_pd3dPrimaryDevice->GetBloomBufferTexture()->GetColorSampler());
+            m_pin3d.m_pd3dPrimaryDevice->FBShader->SetTexture(SHADER_Texture1, m_pin3d.m_pd3dPrimaryDevice->GetBloomBufferTexture()->GetColorSampler());
             m_pin3d.m_pd3dPrimaryDevice->FBShader->SetVector(SHADER_w_h_height, &fb_inv_resolution_05);
             m_pin3d.m_pd3dPrimaryDevice->FBShader->SetTechnique(SHADER_TECHNIQUE_fb_bloom_horiz19x19);
 
@@ -3585,12 +3585,12 @@ void Player::DrawBulbLightBuffer()
             m_pin3d.m_pd3dPrimaryDevice->FBShader->End();
          }
          {
-            m_pin3d.m_pd3dPrimaryDevice->FBShader->SetTextureNull(SHADER_Texture0);
+            m_pin3d.m_pd3dPrimaryDevice->FBShader->SetTextureNull(SHADER_Texture1);
 
             // switch to 'bloom' output buffer for vertical phase of gaussian blur
             m_pin3d.m_pd3dPrimaryDevice->GetBloomBufferTexture()->Activate(true);
 
-            m_pin3d.m_pd3dPrimaryDevice->FBShader->SetTexture(SHADER_Texture0, m_pin3d.m_pd3dPrimaryDevice->GetBloomTmpBufferTexture()->GetColorSampler());
+            m_pin3d.m_pd3dPrimaryDevice->FBShader->SetTexture(SHADER_Texture1, m_pin3d.m_pd3dPrimaryDevice->GetBloomTmpBufferTexture()->GetColorSampler());
             m_pin3d.m_pd3dPrimaryDevice->FBShader->SetVector(SHADER_w_h_height, &fb_inv_resolution_05);
             m_pin3d.m_pd3dPrimaryDevice->FBShader->SetTechnique(SHADER_TECHNIQUE_fb_bloom_vert19x19);
 

--- a/pin/player.cpp
+++ b/pin/player.cpp
@@ -1964,7 +1964,7 @@ void Player::RenderMirrorOverlay()
    m_pin3d.m_pd3dPrimaryDevice->SetRenderStateCulling(RenderDevice::CULL_NONE);
    m_pin3d.m_pd3dPrimaryDevice->SetRenderState(RenderDevice::ZWRITEENABLE, RenderDevice::RS_FALSE);
 
-   m_pin3d.m_pd3dPrimaryDevice->FBShader->Begin(0);
+   m_pin3d.m_pd3dPrimaryDevice->FBShader->Begin();
    m_pin3d.m_pd3dPrimaryDevice->DrawFullscreenTexturedQuad();
    m_pin3d.m_pd3dPrimaryDevice->FBShader->End();
 
@@ -2131,7 +2131,7 @@ void Player::InitStatic()
          m_pin3d.m_pd3dPrimaryDevice->FBShader->SetTechnique(SHADER_TECHNIQUE_fb_mirror);
          m_pin3d.m_pd3dPrimaryDevice->FBShader->SetFloat(SHADER_mirrorFactor, 1.0);
          m_pin3d.m_pd3dPrimaryDevice->FBShader->SetTexture(SHADER_Texture0, m_pin3d.m_pddsStatic->GetColorSampler());
-         m_pin3d.m_pd3dPrimaryDevice->FBShader->Begin(0);
+         m_pin3d.m_pd3dPrimaryDevice->FBShader->Begin();
          m_pin3d.m_pd3dPrimaryDevice->DrawFullscreenTexturedQuad();
          m_pin3d.m_pd3dPrimaryDevice->FBShader->End();
          m_pin3d.m_pd3dPrimaryDevice->FBShader->SetTextureNull(SHADER_Texture0);
@@ -2196,7 +2196,7 @@ void Player::InitStatic()
       m_pin3d.m_pd3dPrimaryDevice->FBShader->SetTechnique(SHADER_TECHNIQUE_fb_mirror);
       m_pin3d.m_pd3dPrimaryDevice->FBShader->SetFloat(SHADER_mirrorFactor, (float)(1.0 / STATIC_PRERENDER_ITERATIONS));
       m_pin3d.m_pd3dPrimaryDevice->FBShader->SetTexture(SHADER_Texture0, accumulationSurface->GetColorSampler());
-      m_pin3d.m_pd3dPrimaryDevice->FBShader->Begin(0);
+      m_pin3d.m_pd3dPrimaryDevice->FBShader->Begin();
       m_pin3d.m_pd3dPrimaryDevice->DrawFullscreenTexturedQuad();
       m_pin3d.m_pd3dPrimaryDevice->FBShader->End();
       m_pin3d.m_pd3dPrimaryDevice->FBShader->SetTextureNull(SHADER_Texture0);
@@ -2296,7 +2296,7 @@ void Player::InitStatic()
              /*sobol*/radical_inverse<3>(i)*(float)(1. / 8.0)); // jitter within (64/8)x(64/8) neighborhood of 64x64 tex, good compromise between blotches and noise
          m_pin3d.m_pd3dPrimaryDevice->FBShader->SetVector(SHADER_w_h_height, &w_h_height);
 
-         m_pin3d.m_pd3dPrimaryDevice->FBShader->Begin(0);
+         m_pin3d.m_pd3dPrimaryDevice->FBShader->Begin();
          m_pin3d.m_pd3dPrimaryDevice->DrawFullscreenTexturedQuad();
          m_pin3d.m_pd3dPrimaryDevice->FBShader->End();
 
@@ -2317,7 +2317,7 @@ void Player::InitStatic()
       m_pin3d.m_pd3dPrimaryDevice->FBShader->SetVector(SHADER_w_h_height, &fb_inv_resolution_05);
       m_pin3d.m_pd3dPrimaryDevice->FBShader->SetTechnique(useAA ? SHADER_TECHNIQUE_fb_tonemap_AO_static : SHADER_TECHNIQUE_fb_tonemap_AO_no_filter_static);
 
-      m_pin3d.m_pd3dPrimaryDevice->FBShader->Begin(0);
+      m_pin3d.m_pd3dPrimaryDevice->FBShader->Begin();
       m_pin3d.m_pd3dPrimaryDevice->DrawFullscreenTexturedQuad();
       m_pin3d.m_pd3dPrimaryDevice->FBShader->End();
 
@@ -3462,7 +3462,7 @@ void Player::DMDdraw(const float DMDposx, const float DMDposy, const float DMDwi
 
       m_pin3d.m_pd3dPrimaryDevice->DMDShader->SetTexture(SHADER_Texture0, m_pin3d.m_pd3dPrimaryDevice->m_texMan.LoadTexture(m_texdmd), false, false);
 
-      m_pin3d.m_pd3dPrimaryDevice->DMDShader->Begin(0);
+      m_pin3d.m_pd3dPrimaryDevice->DMDShader->Begin();
       m_pin3d.m_pd3dPrimaryDevice->DrawTexturedQuad((Vertex3D_TexelOnly*)DMDVerts);
       m_pin3d.m_pd3dPrimaryDevice->DMDShader->End();
    }
@@ -3495,7 +3495,7 @@ void Player::Spritedraw(const float posx, const float posy, const float width, c
    if (tex)
       pd3dDevice->DMDShader->SetTexture(SHADER_Texture0, tex, TextureFilter::TEXTURE_MODE_NONE, false, false, false);
 
-   pd3dDevice->DMDShader->Begin(0);
+   pd3dDevice->DMDShader->Begin();
    pd3dDevice->DrawTexturedQuad((Vertex3D_TexelOnly*)Verts);
    pd3dDevice->DMDShader->End();
 }
@@ -3526,7 +3526,7 @@ void Player::Spritedraw(const float posx, const float posy, const float width, c
    if (tex)
       pd3dDevice->DMDShader->SetTexture(SHADER_Texture0, tex);
 
-   pd3dDevice->DMDShader->Begin(0);
+   pd3dDevice->DMDShader->Begin();
    pd3dDevice->DrawTexturedQuad((Vertex3D_TexelOnly*)Verts);
    pd3dDevice->DMDShader->End();
 }
@@ -3580,7 +3580,7 @@ void Player::DrawBulbLightBuffer()
             m_pin3d.m_pd3dPrimaryDevice->FBShader->SetVector(SHADER_w_h_height, &fb_inv_resolution_05);
             m_pin3d.m_pd3dPrimaryDevice->FBShader->SetTechnique(SHADER_TECHNIQUE_fb_bloom_horiz19x19);
 
-            m_pin3d.m_pd3dPrimaryDevice->FBShader->Begin(0);
+            m_pin3d.m_pd3dPrimaryDevice->FBShader->Begin();
             m_pin3d.m_pd3dPrimaryDevice->DrawFullscreenTexturedQuad();
             m_pin3d.m_pd3dPrimaryDevice->FBShader->End();
          }
@@ -3594,7 +3594,7 @@ void Player::DrawBulbLightBuffer()
             m_pin3d.m_pd3dPrimaryDevice->FBShader->SetVector(SHADER_w_h_height, &fb_inv_resolution_05);
             m_pin3d.m_pd3dPrimaryDevice->FBShader->SetTechnique(SHADER_TECHNIQUE_fb_bloom_vert19x19);
 
-            m_pin3d.m_pd3dPrimaryDevice->FBShader->Begin(0);
+            m_pin3d.m_pd3dPrimaryDevice->FBShader->Begin();
             m_pin3d.m_pd3dPrimaryDevice->DrawFullscreenTexturedQuad();
             m_pin3d.m_pd3dPrimaryDevice->FBShader->End();
          }
@@ -3869,7 +3869,7 @@ void Player::SSRefl()
 
    m_pin3d.m_pd3dPrimaryDevice->FBShader->SetTechnique(SHADER_TECHNIQUE_SSReflection);
 
-   m_pin3d.m_pd3dPrimaryDevice->FBShader->Begin(0);
+   m_pin3d.m_pd3dPrimaryDevice->FBShader->Begin();
    m_pin3d.m_pd3dPrimaryDevice->DrawFullscreenTexturedQuad();
    m_pin3d.m_pd3dPrimaryDevice->FBShader->End();
 }
@@ -3903,7 +3903,7 @@ void Player::Bloom()
       m_pin3d.m_pd3dPrimaryDevice->FBShader->SetVector(SHADER_w_h_height, &fb_inv_resolution);
       m_pin3d.m_pd3dPrimaryDevice->FBShader->SetTechnique(SHADER_TECHNIQUE_fb_bloom);
 
-      m_pin3d.m_pd3dPrimaryDevice->FBShader->Begin(0);
+      m_pin3d.m_pd3dPrimaryDevice->FBShader->Begin();
       m_pin3d.m_pd3dPrimaryDevice->DrawTexturedQuad((Vertex3D_TexelOnly*)shiftedVerts);
       m_pin3d.m_pd3dPrimaryDevice->FBShader->End();
    }
@@ -3918,7 +3918,7 @@ void Player::Bloom()
       m_pin3d.m_pd3dPrimaryDevice->FBShader->SetVector(SHADER_w_h_height, &fb_inv_resolution_05);
       m_pin3d.m_pd3dPrimaryDevice->FBShader->SetTechnique(/*m_low_quality_bloom ? SHADER_TECHNIQUE_fb_bloom_horiz9x9 :*/ SHADER_TECHNIQUE_fb_bloom_horiz39x39);
 
-      m_pin3d.m_pd3dPrimaryDevice->FBShader->Begin(0);
+      m_pin3d.m_pd3dPrimaryDevice->FBShader->Begin();
       m_pin3d.m_pd3dPrimaryDevice->DrawFullscreenTexturedQuad();
       m_pin3d.m_pd3dPrimaryDevice->FBShader->End();
    }
@@ -3933,7 +3933,7 @@ void Player::Bloom()
       m_pin3d.m_pd3dPrimaryDevice->FBShader->SetVector(SHADER_w_h_height, &fb_inv_resolution_05);
       m_pin3d.m_pd3dPrimaryDevice->FBShader->SetTechnique(/*m_low_quality_bloom ? SHADER_TECHNIQUE_fb_bloom_vert9x9 :*/ SHADER_TECHNIQUE_fb_bloom_vert39x39);
 
-      m_pin3d.m_pd3dPrimaryDevice->FBShader->Begin(0);
+      m_pin3d.m_pd3dPrimaryDevice->FBShader->Begin();
       m_pin3d.m_pd3dPrimaryDevice->DrawFullscreenTexturedQuad();
       m_pin3d.m_pd3dPrimaryDevice->FBShader->End();
    }
@@ -3965,7 +3965,7 @@ void Player::RenderFXAA(const int stereo, const bool SMAA, const bool DLAA, cons
                                                       (FXAA2 ? SHADER_TECHNIQUE_FXAA2 : 
                                                                SHADER_TECHNIQUE_FXAA1)))));
 
-   m_pin3d.m_pd3dPrimaryDevice->FBShader->Begin(0);
+   m_pin3d.m_pd3dPrimaryDevice->FBShader->Begin();
    m_pin3d.m_pd3dPrimaryDevice->DrawFullscreenTexturedQuad();
    m_pin3d.m_pd3dPrimaryDevice->FBShader->End();
 
@@ -3988,7 +3988,7 @@ void Player::RenderFXAA(const int stereo, const bool SMAA, const bool DLAA, cons
 
       m_pin3d.m_pd3dPrimaryDevice->FBShader->SetTechnique(SMAA ? SHADER_TECHNIQUE_SMAA_BlendWeightCalculation : SHADER_TECHNIQUE_DLAA);
 
-      m_pin3d.m_pd3dPrimaryDevice->FBShader->Begin(0);
+      m_pin3d.m_pd3dPrimaryDevice->FBShader->Begin();
       m_pin3d.m_pd3dPrimaryDevice->DrawFullscreenTexturedQuad();
       m_pin3d.m_pd3dPrimaryDevice->FBShader->End();
 
@@ -4004,7 +4004,7 @@ void Player::RenderFXAA(const int stereo, const bool SMAA, const bool DLAA, cons
 
          m_pin3d.m_pd3dPrimaryDevice->FBShader->SetTechnique(SHADER_TECHNIQUE_SMAA_NeighborhoodBlending);
 
-         m_pin3d.m_pd3dPrimaryDevice->FBShader->Begin(0);
+         m_pin3d.m_pd3dPrimaryDevice->FBShader->Begin();
          m_pin3d.m_pd3dPrimaryDevice->DrawFullscreenTexturedQuad();
          m_pin3d.m_pd3dPrimaryDevice->FBShader->End();
 
@@ -4106,14 +4106,14 @@ void Player::RenderStereo(int stereo3D, bool shaderAA)
          leftTexture->Activate(false);
 
          m_pin3d.m_pd3dPrimaryDevice->StereoShader->SetFloat(SHADER_eye, 0.0f);
-         m_pin3d.m_pd3dPrimaryDevice->StereoShader->Begin(0);
+         m_pin3d.m_pd3dPrimaryDevice->StereoShader->Begin();
          m_pin3d.m_pd3dPrimaryDevice->DrawFullscreenTexturedQuad();
          m_pin3d.m_pd3dPrimaryDevice->StereoShader->End();
 
          rightTexture->Activate(false);
 
          m_pin3d.m_pd3dPrimaryDevice->StereoShader->SetFloat(SHADER_eye, 1.0f);
-         m_pin3d.m_pd3dPrimaryDevice->StereoShader->Begin(0);
+         m_pin3d.m_pd3dPrimaryDevice->StereoShader->Begin();
          m_pin3d.m_pd3dPrimaryDevice->DrawFullscreenTexturedQuad();
          m_pin3d.m_pd3dPrimaryDevice->StereoShader->End();
 
@@ -4122,7 +4122,7 @@ void Player::RenderStereo(int stereo3D, bool shaderAA)
          {
             m_pin3d.m_pd3dPrimaryDevice->GetOutputBackBuffer()->Activate(false);
             m_pin3d.m_pd3dPrimaryDevice->StereoShader->SetFloat(SHADER_eye, 1.0f);
-            m_pin3d.m_pd3dPrimaryDevice->StereoShader->Begin(0);
+            m_pin3d.m_pd3dPrimaryDevice->StereoShader->Begin();
             m_pin3d.m_pd3dPrimaryDevice->DrawFullscreenTexturedQuad();
             m_pin3d.m_pd3dPrimaryDevice->StereoShader->End();
          }
@@ -4164,7 +4164,7 @@ void Player::RenderStereo(int stereo3D, bool shaderAA)
       m_pin3d.m_pd3dPrimaryDevice->StereoShader->SetVector(SHADER_ms_zpd_ya_td, &ms_zpd_ya_td);
       m_pin3d.m_pd3dPrimaryDevice->StereoShader->SetVector(SHADER_Anaglyph_DeSaturation_Contrast, &a_ds_c);
       m_pin3d.m_pd3dPrimaryDevice->GetOutputBackBuffer()->Activate(false);
-      m_pin3d.m_pd3dPrimaryDevice->StereoShader->Begin(0);
+      m_pin3d.m_pd3dPrimaryDevice->StereoShader->Begin();
       m_pin3d.m_pd3dPrimaryDevice->DrawFullscreenTexturedQuad();
       m_pin3d.m_pd3dPrimaryDevice->StereoShader->End();
    }
@@ -4174,7 +4174,7 @@ void Player::RenderStereo(int stereo3D, bool shaderAA)
       m_pin3d.m_pd3dPrimaryDevice->StereoShader->SetTechnique(stereo3D == STEREO_INT ? SHADER_TECHNIQUE_stereo_Int : SHADER_TECHNIQUE_stereo_Flipped_Int);
       m_pin3d.m_pd3dPrimaryDevice->StereoShader->SetTexture(SHADER_Texture0, m_pin3d.m_pd3dPrimaryDevice->GetBackBufferPPTexture1()->GetColorSampler());
       m_pin3d.m_pd3dPrimaryDevice->GetOutputBackBuffer()->Activate(false);
-      m_pin3d.m_pd3dPrimaryDevice->StereoShader->Begin(0);
+      m_pin3d.m_pd3dPrimaryDevice->StereoShader->Begin();
       m_pin3d.m_pd3dPrimaryDevice->DrawFullscreenTexturedQuad();
       m_pin3d.m_pd3dPrimaryDevice->StereoShader->End();
    }
@@ -4765,7 +4765,7 @@ void Player::PostProcess(const bool ambientOcclusion)
 
       m_pin3d.m_pd3dPrimaryDevice->FBShader->SetTechnique(SHADER_TECHNIQUE_AO);
 
-      m_pin3d.m_pd3dPrimaryDevice->FBShader->Begin(0);
+      m_pin3d.m_pd3dPrimaryDevice->FBShader->Begin();
       m_pin3d.m_pd3dPrimaryDevice->DrawFullscreenTexturedQuad();
       m_pin3d.m_pd3dPrimaryDevice->FBShader->End();
 
@@ -4822,7 +4822,7 @@ void Player::PostProcess(const bool ambientOcclusion)
             ? SHADER_TECHNIQUE_fb_tonemap
             : (m_BWrendering == 1 ? SHADER_TECHNIQUE_fb_tonemap_no_filterRG : (m_BWrendering == 2 ? SHADER_TECHNIQUE_fb_tonemap_no_filterR : SHADER_TECHNIQUE_fb_tonemap_no_filterRGB)));
 
-   m_pin3d.m_pd3dPrimaryDevice->FBShader->Begin(0);
+   m_pin3d.m_pd3dPrimaryDevice->FBShader->Begin();
    m_pin3d.m_pd3dPrimaryDevice->DrawTexturedQuad((Vertex3D_TexelOnly *)shiftedVerts);
    m_pin3d.m_pd3dPrimaryDevice->FBShader->End();
 
@@ -5523,7 +5523,7 @@ void Player::GetBallAspectRatio(const Ball * const pball, Vertex2D &stretch, con
    m_pin3d.m_pd3dDevice->SetRenderState(RenderDevice::DESTBLEND, RenderDevice::DST_ALPHA);
    m_ballShader->SetTechnique("RenderBallReflection");
 
-   m_ballShader->Begin(0);
+   m_ballShader->Begin();
    m_pin3d.m_pd3dDevice->DrawIndexedPrimitiveVB(RenderDevice::TRIANGLELIST, MY_D3DFVF_NOTEX2_VERTEX, ballVertexBuffer, 0, lowDetailBall ? basicBallLoNumVertices : basicBallMidNumVertices, ballIndexBuffer, 0, lowDetailBall ? basicBallLoNumFaces : basicBallMidNumFaces);
    m_ballShader->End();
 
@@ -5709,7 +5709,7 @@ void Player::DrawBalls()
       else //if (!m_cabinetMode && !pball->m_decalMode)
          m_ballShader->SetTechnique(SHADER_TECHNIQUE_RenderBall);
 
-      m_ballShader->Begin(0);
+      m_ballShader->Begin();
       m_pin3d.m_pd3dPrimaryDevice->DrawIndexedPrimitiveVB(RenderDevice::TRIANGLELIST, MY_D3DFVF_NOTEX2_VERTEX, m_ballVertexBuffer, 0, lowDetailBall ? basicBallLoNumVertices : basicBallMidNumVertices, m_ballIndexBuffer, 0, lowDetailBall ? basicBallLoNumFaces : basicBallMidNumFaces);
       m_ballShader->End();
 
@@ -5805,7 +5805,7 @@ void Player::DrawBalls()
             m_pin3d.EnableAlphaBlend(false);
 
             m_ballShader->SetTechnique(SHADER_TECHNIQUE_RenderBallTrail);
-            m_ballShader->Begin(0);
+            m_ballShader->Begin();
             m_pin3d.m_pd3dPrimaryDevice->DrawPrimitiveVB(RenderDevice::TRIANGLESTRIP, MY_D3DFVF_NOTEX2_VERTEX, m_ballTrailVertexBuffer, 0, num_rgv3D, true);
             m_ballShader->End();
          }

--- a/pin/player.cpp
+++ b/pin/player.cpp
@@ -2016,9 +2016,11 @@ void Player::InitStatic()
    // if rendering static/with heavy oversampling, disable the aniso/trilinear filter to get a sharper/more precise result overall!
    if (!m_dynamicMode)
    {
+#ifdef ENABLE_SDL
       // The code will fail if the static render target is MSAA (the copy operation we are performing are not allowed)
       assert(!m_pin3d.m_pddsStatic->IsMSAA());
       accumulationSurface = m_pin3d.m_pddsStatic->Duplicate();
+#endif
       m_isRenderingStatic = true;
       // set up the texture filter again, so that this is triggered correctly
       m_pin3d.m_pd3dPrimaryDevice->SetTextureFilter(0, TEXTURE_MODE_TRILINEAR);
@@ -2067,9 +2069,10 @@ void Player::InitStatic()
                RenderStaticMirror(false);
 
          // exclude playfield depth as dynamic mirror objects have to be added later-on
-         m_pin3d.m_pd3dPrimaryDevice->SetRenderState(RenderDevice::ZWRITEENABLE, RenderDevice::RS_FALSE);
+         // FIXME disabled since mirror is not yet implemented. This needs to be reactivated in the mirror fix 
+         // m_pin3d.m_pd3dPrimaryDevice->SetRenderState(RenderDevice::ZWRITEENABLE, RenderDevice::RS_FALSE);
          m_pin3d.RenderPlayfieldGraphics(false);
-         m_pin3d.m_pd3dPrimaryDevice->SetRenderState(RenderDevice::ZWRITEENABLE, RenderDevice::RS_TRUE);
+         //m_pin3d.m_pd3dPrimaryDevice->SetRenderState(RenderDevice::ZWRITEENABLE, RenderDevice::RS_TRUE);
 
          if (m_ptable->m_reflectElementsOnPlayfield /*&& m_pf_refl*/)
             RenderMirrorOverlay();
@@ -2126,7 +2129,7 @@ void Player::InitStatic()
       {
 #ifdef ENABLE_SDL
          // Rendering is done to m_pin3d.m_pddsStatic then accumulated to accumulationSurface
-         // We use the framebuffer mirror shader with copy a weighted of the incoming texture
+         // We use the framebuffer mirror shader wich copy a weighted version of the bound texture
          accumulationSurface->Activate(true);
          m_pin3d.m_pd3dPrimaryDevice->BeginScene();
          m_pin3d.EnableAlphaBlend(true);
@@ -4169,7 +4172,7 @@ void Player::RenderStereo(int stereo3D, bool shaderAA)
       m_pin3d.m_pd3dPrimaryDevice->StereoShader->SetTexture(SHADER_tex_stereo_fb, m_pin3d.m_pd3dPrimaryDevice->GetBackBufferPPTexture1()->GetColorSampler());
       m_pin3d.m_pd3dPrimaryDevice->StereoShader->SetVector(SHADER_ms_zpd_ya_td, &ms_zpd_ya_td);
       m_pin3d.m_pd3dPrimaryDevice->StereoShader->SetVector(SHADER_Anaglyph_DeSaturation_Contrast, &a_ds_c);
-      m_pin3d.m_pd3dPrimaryDevice->GetOutputBackBuffer()->Activate(false);
+      m_pin3d.m_pd3dPrimaryDevice->GetOutputBackBuffer()->Activate(true);
       m_pin3d.m_pd3dPrimaryDevice->StereoShader->Begin();
       m_pin3d.m_pd3dPrimaryDevice->DrawFullscreenTexturedQuad();
       m_pin3d.m_pd3dPrimaryDevice->StereoShader->End();
@@ -4179,7 +4182,7 @@ void Player::RenderStereo(int stereo3D, bool shaderAA)
       // Interlaced, handled in shader
       m_pin3d.m_pd3dPrimaryDevice->StereoShader->SetTechnique(stereo3D == STEREO_INT ? SHADER_TECHNIQUE_stereo_Int : SHADER_TECHNIQUE_stereo_Flipped_Int);
       m_pin3d.m_pd3dPrimaryDevice->StereoShader->SetTexture(SHADER_tex_stereo_fb, m_pin3d.m_pd3dPrimaryDevice->GetBackBufferPPTexture1()->GetColorSampler());
-      m_pin3d.m_pd3dPrimaryDevice->GetOutputBackBuffer()->Activate(false);
+      m_pin3d.m_pd3dPrimaryDevice->GetOutputBackBuffer()->Activate(true);
       m_pin3d.m_pd3dPrimaryDevice->StereoShader->Begin();
       m_pin3d.m_pd3dPrimaryDevice->DrawFullscreenTexturedQuad();
       m_pin3d.m_pd3dPrimaryDevice->StereoShader->End();

--- a/pin/player.h
+++ b/pin/player.h
@@ -286,8 +286,8 @@ public:
    Player(const bool cameraMode, PinTable * const ptable);
    virtual ~Player();
 
-   void Player::CreateWnd(HWND parent = 0);
-   virtual void PreRegisterClass(WNDCLASS &wc) override;
+   void CreateWnd(HWND parent = 0);
+   virtual void PreRegisterClass(WNDCLASS& wc) override;
    virtual void PreCreate(CREATESTRUCT& cs) override;
    virtual void OnInitialUpdate() override;
    virtual LRESULT WndProc(UINT uMsg, WPARAM wParam, LPARAM lParam) override;

--- a/pin/player.h
+++ b/pin/player.h
@@ -376,6 +376,7 @@ public:
    VertexBuffer *m_ballTrailVertexBuffer;
    bool m_antiStretchBall;
 
+   bool m_dynamicMode;
    bool m_cameraMode;
    int m_backdropSettingActive;
    PinTable *m_ptable;

--- a/pin3d.cpp
+++ b/pin3d.cpp
@@ -1069,7 +1069,7 @@ void Pin3D::RenderPlayfieldGraphics(const bool depth_only)
        {
            SetPrimaryTextureFilter(0, TEXTURE_MODE_ANISOTROPIC);
            m_pd3dPrimaryDevice->basicShader->SetTechnique(SHADER_TECHNIQUE_basic_depth_only_with_texture);
-           m_pd3dPrimaryDevice->basicShader->SetTexture(SHADER_Texture0, pin, TextureFilter::TEXTURE_MODE_TRILINEAR, true, true, false);
+           m_pd3dPrimaryDevice->basicShader->SetTexture(SHADER_tex_base_color, pin, TextureFilter::TEXTURE_MODE_TRILINEAR, true, true, false);
            m_pd3dPrimaryDevice->basicShader->SetAlphaTestValue(pin->m_alphaTestValue * (float)(1.0 / 255.0));
        }
        else // No image by that name
@@ -1083,7 +1083,7 @@ void Pin3D::RenderPlayfieldGraphics(const bool depth_only)
        {
            SetPrimaryTextureFilter(0, TEXTURE_MODE_ANISOTROPIC);
            m_pd3dPrimaryDevice->basicShader->SetTechniqueMetal(SHADER_TECHNIQUE_basic_with_texture, mat->m_bIsMetal);
-           m_pd3dPrimaryDevice->basicShader->SetTexture(SHADER_Texture0, pin, TextureFilter::TEXTURE_MODE_TRILINEAR, true, true, false);
+           m_pd3dPrimaryDevice->basicShader->SetTexture(SHADER_tex_base_color, pin, TextureFilter::TEXTURE_MODE_TRILINEAR, true, true, false);
            m_pd3dPrimaryDevice->basicShader->SetAlphaTestValue(pin->m_alphaTestValue * (float)(1.0 / 255.0));
        }
        else // No image by that name
@@ -1115,7 +1115,7 @@ void Pin3D::RenderPlayfieldGraphics(const bool depth_only)
 
    if (pin)
    {
-      //m_pd3dPrimaryDevice->basicShader->SetTextureNull(SHADER_Texture0);
+      //m_pd3dPrimaryDevice->basicShader->SetTextureNull(SHADER_tex_base_color);
       //m_pd3dPrimaryDevice->m_texMan.UnloadTexture(pin->m_pdsBuffer); //!! is used by ball reflection later-on
       SetPrimaryTextureFilter(0, TEXTURE_MODE_TRILINEAR);
    }

--- a/pin3d.cpp
+++ b/pin3d.cpp
@@ -1093,7 +1093,7 @@ void Pin3D::RenderPlayfieldGraphics(const bool depth_only)
    if (!g_pplayer->m_meshAsPlayfield)
    {
       assert(m_tableVBuffer != nullptr);
-      m_pd3dPrimaryDevice->basicShader->Begin(0);
+      m_pd3dPrimaryDevice->basicShader->Begin();
       m_pd3dPrimaryDevice->DrawPrimitiveVB(RenderDevice::TRIANGLESTRIP, MY_D3DFVF_NOTEX2_VERTEX, m_tableVBuffer, 0, 4, true);
       m_pd3dPrimaryDevice->basicShader->End();
    }

--- a/pin3d.cpp
+++ b/pin3d.cpp
@@ -481,7 +481,9 @@ HRESULT Pin3D::InitPrimary(const bool fullScreen, const int colordepth, int &ref
 
    m_pddsBackBuffer = m_pd3dPrimaryDevice->GetBackBufferTexture();
 
-   m_pddsStatic = m_pddsBackBuffer->Duplicate();
+   // Static render target is a copy of the main back buffer without MSAA
+   m_pddsStatic = new RenderTarget(m_pd3dPrimaryDevice, m_pddsBackBuffer->GetWidth(), m_pddsBackBuffer->GetHeight(), m_pddsBackBuffer->GetColorFormat(), m_pddsBackBuffer->HasDepth(),
+      false, m_pddsBackBuffer->GetStereo(), "Failed to create static render target");
 
    if (m_pd3dPrimaryDevice->DepthBufferReadBackAvailable() && useAO)
    {

--- a/pin3d.h
+++ b/pin3d.h
@@ -74,7 +74,7 @@ public:
    Pin3D();
    ~Pin3D();
 
-   HRESULT InitPin3D(const bool fullScreen, const int width, const int height, const int colordepth, int& refreshrate, const int VSync, const float AAfactor, const StereoMode stereo3D, const unsigned int FXAA, const bool sharpen, const bool useAO, const bool ss_refl);
+   HRESULT InitPin3D(const bool fullScreen, const int width, const int height, const int colordepth, int &refreshrate, const int VSync, const float AAfactor, const StereoMode stereo3D, const unsigned int FXAA, const bool sharpen, const bool useAO, const bool ss_refl);
 
    void InitLayoutFS();
    void InitLayout(const bool FSS_mode, const float max_separation, const float xpixoff = 0.f, const float ypixoff = 0.f);

--- a/pininput.cpp
+++ b/pininput.cpp
@@ -773,7 +773,7 @@ void PinInput::Init(const HWND hwnd)
    m_hwnd = hwnd;
 
 #if defined(ENABLE_SDL_INPUT)
-   SDL_Init(SDL_INIT_JOYSTICK);
+   SDL_InitSubSystem(SDL_INIT_JOYSTICK);
 #endif
 
    HRESULT hr;
@@ -910,7 +910,7 @@ void PinInput::UnInit()
    //{exit (-1500);}
 
 #if defined(ENABLE_SDL_INPUT)
-   SDL_Quit();
+   SDL_QuitSubSystem(SDL_INIT_JOYSTICK);
 #endif
 
 #ifdef USE_DINPUT_FOR_KEYBOARD

--- a/plunger.cpp
+++ b/plunger.cpp
@@ -247,7 +247,7 @@ void Plunger::RenderDynamic()
    else
       pd3dDevice->basicShader->SetTechniqueMetal(SHADER_TECHNIQUE_basic_without_texture, mat->m_bIsMetal);
 
-   pd3dDevice->basicShader->Begin(0);
+   pd3dDevice->basicShader->Begin();
    pd3dDevice->DrawIndexedPrimitiveVB(RenderDevice::TRIANGLELIST, MY_D3DFVF_NOTEX2_VERTEX, m_vertexBuffer,
       frame*m_vtsPerFrame, m_vtsPerFrame,
       m_indexBuffer, 0, m_indicesPerFrame);

--- a/plunger.cpp
+++ b/plunger.cpp
@@ -241,7 +241,7 @@ void Plunger::RenderDynamic()
    if (pin)
    {
       pd3dDevice->basicShader->SetTechniqueMetal(SHADER_TECHNIQUE_basic_with_texture, mat->m_bIsMetal);
-      pd3dDevice->basicShader->SetTexture(SHADER_Texture0, pin, TextureFilter::TEXTURE_MODE_TRILINEAR, false, false, false);
+      pd3dDevice->basicShader->SetTexture(SHADER_tex_base_color, pin, TextureFilter::TEXTURE_MODE_TRILINEAR, false, false, false);
       pd3dDevice->basicShader->SetAlphaTestValue(pin->m_alphaTestValue * (float)(1.0 / 255.0));
    }
    else

--- a/primitive.cpp
+++ b/primitive.cpp
@@ -1239,7 +1239,7 @@ void Primitive::RenderObject()
       if (g_pplayer->m_texPUP && m_d.m_isBackGlassImage)
       {
          pd3dDevice->basicShader->SetTechniqueMetal(SHADER_TECHNIQUE_basic_with_texture, mat->m_bIsMetal);
-         pd3dDevice->basicShader->SetTexture(SHADER_Texture0, pd3dDevice->m_texMan.LoadTexture(g_pplayer->m_texPUP, TextureFilter::TEXTURE_MODE_TRILINEAR, false, false, false));
+         pd3dDevice->basicShader->SetTexture(SHADER_tex_base_color, pd3dDevice->m_texMan.LoadTexture(g_pplayer->m_texPUP, TextureFilter::TEXTURE_MODE_TRILINEAR, false, false, false));
 
          //g_pplayer->m_pin3d.SetPrimaryTextureFilter(0, TEXTURE_MODE_TRILINEAR);
          // accommodate models with UV coords outside of [0,1]
@@ -1251,8 +1251,8 @@ void Primitive::RenderObject()
          if (pin && nMap)
          {
             pd3dDevice->basicShader->SetTechniqueMetal(SHADER_TECHNIQUE_basic_with_texture, mat->m_bIsMetal);
-            pd3dDevice->basicShader->SetTexture(SHADER_Texture0, pin, TextureFilter::TEXTURE_MODE_TRILINEAR, false, false, false);
-            pd3dDevice->basicShader->SetTexture(SHADER_Texture4, nMap, TextureFilter::TEXTURE_MODE_TRILINEAR, false, false, true);
+            pd3dDevice->basicShader->SetTexture(SHADER_tex_base_color, pin, TextureFilter::TEXTURE_MODE_TRILINEAR, false, false, false);
+            pd3dDevice->basicShader->SetTexture(SHADER_tex_base_normalmap, nMap, TextureFilter::TEXTURE_MODE_TRILINEAR, false, false, true);
             pd3dDevice->basicShader->SetAlphaTestValue(pin->m_alphaTestValue * (float)(1.0 / 255.0));
             pd3dDevice->basicShader->SetBool(SHADER_objectSpaceNormalMap, m_d.m_objectSpaceNormalMap);
             //g_pplayer->m_pin3d.SetPrimaryTextureFilter(0, TEXTURE_MODE_TRILINEAR);
@@ -1262,7 +1262,7 @@ void Primitive::RenderObject()
          else if (pin)
          {
             pd3dDevice->basicShader->SetTechniqueMetal(SHADER_TECHNIQUE_basic_with_texture, mat->m_bIsMetal);
-            pd3dDevice->basicShader->SetTexture(SHADER_Texture0, pin, TextureFilter::TEXTURE_MODE_TRILINEAR, false, false, false);
+            pd3dDevice->basicShader->SetTexture(SHADER_tex_base_color, pin, TextureFilter::TEXTURE_MODE_TRILINEAR, false, false, false);
             pd3dDevice->basicShader->SetAlphaTestValue(pin->m_alphaTestValue * (float)(1.0 / 255.0));
 
             //g_pplayer->m_pin3d.SetPrimaryTextureFilter(0, TEXTURE_MODE_TRILINEAR);

--- a/primitive.cpp
+++ b/primitive.cpp
@@ -1294,7 +1294,7 @@ void Primitive::RenderObject()
       }
 
       // draw the mesh
-      pd3dDevice->basicShader->Begin(0);
+      pd3dDevice->basicShader->Begin();
       if (m_d.m_groupdRendering)
          pd3dDevice->DrawIndexedPrimitiveVB(RenderDevice::TRIANGLELIST, MY_D3DFVF_NOTEX2_VERTEX, m_vertexBuffer, 0, m_numGroupVertices, m_indexBuffer, 0, m_numGroupIndices);
       else
@@ -1304,7 +1304,7 @@ void Primitive::RenderObject()
       if (m_d.m_backfacesEnabled && mat->m_bOpacityActive)
       {
          pd3dDevice->SetRenderStateCulling(RenderDevice::CULL_CCW);
-         pd3dDevice->basicShader->Begin(0);
+         pd3dDevice->basicShader->Begin();
          if (m_d.m_groupdRendering)
             pd3dDevice->DrawIndexedPrimitiveVB(RenderDevice::TRIANGLELIST, MY_D3DFVF_NOTEX2_VERTEX, m_vertexBuffer, 0, m_numGroupVertices, m_indexBuffer, 0, m_numGroupIndices);
          else
@@ -1333,7 +1333,7 @@ void Primitive::RenderObject()
       //pd3dDevice->SetRenderStateCulling(RenderDevice::CULL_CCW); // don't mess with the render states when doing playfield rendering
       // set transform
       g_pplayer->UpdateBasicShaderMatrix(m_fullMatrix);
-      pd3dDevice->basicShader->Begin(0);
+      pd3dDevice->basicShader->Begin();
       pd3dDevice->DrawIndexedPrimitiveVB(RenderDevice::TRIANGLELIST, MY_D3DFVF_NOTEX2_VERTEX, m_vertexBuffer, 0, (DWORD)m_mesh.NumVertices(), m_indexBuffer, 0, (DWORD)m_mesh.NumIndices());
       pd3dDevice->basicShader->End();
       // reset transform

--- a/ramp.cpp
+++ b/ramp.cpp
@@ -923,7 +923,7 @@ void Ramp::RenderStaticHabitrail(const Material * const mat)
       pd3dDevice->basicShader->SetTechniqueMetal(SHADER_TECHNIQUE_basic_without_texture, mat->m_bIsMetal);
    else
    {
-      pd3dDevice->basicShader->SetTexture(SHADER_Texture0, pin, TextureFilter::TEXTURE_MODE_TRILINEAR, false, false, false);
+      pd3dDevice->basicShader->SetTexture(SHADER_tex_base_color, pin, TextureFilter::TEXTURE_MODE_TRILINEAR, false, false, false);
       pd3dDevice->basicShader->SetTechniqueMetal(SHADER_TECHNIQUE_basic_with_texture, mat->m_bIsMetal);
 
       //g_pplayer->m_pin3d.SetPrimaryTextureFilter(0, TEXTURE_MODE_TRILINEAR);
@@ -2146,7 +2146,7 @@ void Ramp::RenderRamp(const Material * const mat)
       if (pin)
       {
          pd3dDevice->basicShader->SetTechniqueMetal(SHADER_TECHNIQUE_basic_with_texture, mat->m_bIsMetal);
-         pd3dDevice->basicShader->SetTexture(SHADER_Texture0, pin, TextureFilter::TEXTURE_MODE_TRILINEAR, false, false, false);
+         pd3dDevice->basicShader->SetTexture(SHADER_tex_base_color, pin, TextureFilter::TEXTURE_MODE_TRILINEAR, false, false, false);
          pd3dDevice->basicShader->SetAlphaTestValue(pin->m_alphaTestValue * (float)(1.0 / 255.0));
 
          //ppin3d->SetPrimaryTextureFilter( 0, TEXTURE_MODE_TRILINEAR );

--- a/ramp.cpp
+++ b/ramp.cpp
@@ -937,7 +937,7 @@ void Ramp::RenderStaticHabitrail(const Material * const mat)
          matTrafo.SetIdentity();
          matTrafo._43 = m_d.m_wireDistanceY*0.5f;
          g_pplayer->UpdateBasicShaderMatrix(matTrafo);
-         pd3dDevice->basicShader->Begin(0);
+         pd3dDevice->basicShader->Begin();
          pd3dDevice->DrawIndexedPrimitiveVB(RenderDevice::TRIANGLELIST, MY_D3DFVF_NOTEX2_VERTEX, m_dynamicVertexBuffer, 0, m_numVertices, m_dynamicIndexBuffer, 0, m_numIndices);
          pd3dDevice->DrawIndexedPrimitiveVB(RenderDevice::TRIANGLELIST, MY_D3DFVF_NOTEX2_VERTEX, m_dynamicVertexBuffer2, 0, m_numVertices, m_dynamicIndexBuffer, 0, m_numIndices);
          pd3dDevice->basicShader->End();
@@ -945,7 +945,7 @@ void Ramp::RenderStaticHabitrail(const Material * const mat)
       matTrafo.SetIdentity();
       matTrafo._43 = 3.0f;                // raise the wire a bit because the ball runs on a flat ramp physically
       g_pplayer->UpdateBasicShaderMatrix(matTrafo);
-      pd3dDevice->basicShader->Begin(0);
+      pd3dDevice->basicShader->Begin();
       pd3dDevice->DrawIndexedPrimitiveVB(RenderDevice::TRIANGLELIST, MY_D3DFVF_NOTEX2_VERTEX, m_dynamicVertexBuffer, 0, m_numVertices, m_dynamicIndexBuffer, 0, m_numIndices);
       pd3dDevice->DrawIndexedPrimitiveVB(RenderDevice::TRIANGLELIST, MY_D3DFVF_NOTEX2_VERTEX, m_dynamicVertexBuffer2, 0, m_numVertices, m_dynamicIndexBuffer, 0, m_numIndices);
       pd3dDevice->basicShader->End();
@@ -957,13 +957,13 @@ void Ramp::RenderStaticHabitrail(const Material * const mat)
       matTrafo.SetIdentity();
       matTrafo._43 = m_d.m_wireDistanceY*0.5f;
       g_pplayer->UpdateBasicShaderMatrix(matTrafo);
-      pd3dDevice->basicShader->Begin(0);
+      pd3dDevice->basicShader->Begin();
       pd3dDevice->DrawIndexedPrimitiveVB(RenderDevice::TRIANGLELIST, MY_D3DFVF_NOTEX2_VERTEX, (m_d.m_type == RampType3WireRight) ? m_dynamicVertexBuffer : m_dynamicVertexBuffer2, 0, m_numVertices, m_dynamicIndexBuffer, 0, m_numIndices);
       pd3dDevice->basicShader->End();
       matTrafo.SetIdentity();
       matTrafo._43 = 3.0f;                // raise the wire a bit because the ball runs on a flat ramp physically
       g_pplayer->UpdateBasicShaderMatrix(matTrafo);
-      pd3dDevice->basicShader->Begin(0);
+      pd3dDevice->basicShader->Begin();
       pd3dDevice->DrawIndexedPrimitiveVB(RenderDevice::TRIANGLELIST, MY_D3DFVF_NOTEX2_VERTEX, m_dynamicVertexBuffer, 0, m_numVertices, m_dynamicIndexBuffer, 0, m_numIndices);
       pd3dDevice->DrawIndexedPrimitiveVB(RenderDevice::TRIANGLELIST, MY_D3DFVF_NOTEX2_VERTEX, m_dynamicVertexBuffer2, 0, m_numVertices, m_dynamicIndexBuffer, 0, m_numIndices);
       pd3dDevice->basicShader->End();
@@ -971,7 +971,7 @@ void Ramp::RenderStaticHabitrail(const Material * const mat)
    }
    else
    {
-      pd3dDevice->basicShader->Begin(0);
+      pd3dDevice->basicShader->Begin();
       pd3dDevice->DrawIndexedPrimitiveVB(RenderDevice::TRIANGLELIST, MY_D3DFVF_NOTEX2_VERTEX, m_dynamicVertexBuffer, 0, m_numVertices, m_dynamicIndexBuffer, 0, m_numIndices);
       pd3dDevice->basicShader->End();
    }
@@ -2159,14 +2159,14 @@ void Ramp::RenderRamp(const Material * const mat)
       if (m_d.m_rightwallheightvisible != 0.f && m_d.m_leftwallheightvisible != 0.f && (!pin || m_d.m_imageWalls))
       {
          // both walls with image and floor
-         pd3dDevice->basicShader->Begin(0);
+         pd3dDevice->basicShader->Begin();
          pd3dDevice->DrawIndexedPrimitiveVB(RenderDevice::TRIANGLELIST, MY_D3DFVF_NOTEX2_VERTEX, m_dynamicVertexBuffer, 0, m_numVertices * 3, m_dynamicIndexBuffer, 0, (m_rampVertex - 1) * 6 * 3);
          pd3dDevice->basicShader->End();
       }
       else
       {
          // only floor
-         pd3dDevice->basicShader->Begin(0);
+         pd3dDevice->basicShader->Begin();
          pd3dDevice->DrawIndexedPrimitiveVB(RenderDevice::TRIANGLELIST, MY_D3DFVF_NOTEX2_VERTEX, m_dynamicVertexBuffer, 0, m_numVertices, m_dynamicIndexBuffer, 0, (m_rampVertex - 1) * 6);
 
          if (m_d.m_rightwallheightvisible != 0.f || m_d.m_leftwallheightvisible != 0.f)
@@ -2175,7 +2175,7 @@ void Ramp::RenderRamp(const Material * const mat)
             {
                pd3dDevice->basicShader->End();
                pd3dDevice->basicShader->SetTechniqueMetal(SHADER_TECHNIQUE_basic_without_texture, mat->m_bIsMetal);
-               pd3dDevice->basicShader->Begin(0);
+               pd3dDevice->basicShader->Begin();
             }
 
             if (m_d.m_rightwallheightvisible != 0.f && m_d.m_leftwallheightvisible != 0.f) //only render left & right side if the height is >0

--- a/regutil.cpp
+++ b/regutil.cpp
@@ -487,7 +487,7 @@ static HRESULT RegDelnodeRecurse(const HKEY hKeyRoot, char lpSubKey[MAX_PATH * 2
 
    LONG lResult = RegDeleteKey(hKeyRoot, lpSubKey);
 
-   if (lResult == ERROR_SUCCESS)
+   if (lResult == ERROR_SUCCESS || lResult == ERROR_FILE_NOT_FOUND)
       return S_OK;
 
    HKEY hKey;

--- a/rubber.cpp
+++ b/rubber.cpp
@@ -1265,7 +1265,7 @@ void Rubber::RenderObject()
    else
       pd3dDevice->basicShader->SetTechniqueMetal(SHADER_TECHNIQUE_basic_without_texture, mat->m_bIsMetal);
 
-   pd3dDevice->basicShader->Begin(0);
+   pd3dDevice->basicShader->Begin();
    pd3dDevice->DrawIndexedPrimitiveVB(RenderDevice::TRIANGLELIST, MY_D3DFVF_NOTEX2_VERTEX, m_dynamicVertexBuffer, 0, m_numVertices, m_dynamicIndexBuffer, 0, m_numIndices);
    pd3dDevice->basicShader->End();
 }

--- a/rubber.cpp
+++ b/rubber.cpp
@@ -1259,7 +1259,7 @@ void Rubber::RenderObject()
    if (pin)
    {
       pd3dDevice->basicShader->SetTechniqueMetal(SHADER_TECHNIQUE_basic_with_texture, mat->m_bIsMetal);
-      pd3dDevice->basicShader->SetTexture(SHADER_Texture0, pin, TextureFilter::TEXTURE_MODE_TRILINEAR, false, false, false);
+      pd3dDevice->basicShader->SetTexture(SHADER_tex_base_color, pin, TextureFilter::TEXTURE_MODE_TRILINEAR, false, false, false);
       pd3dDevice->basicShader->SetAlphaTestValue(pin->m_alphaTestValue * (float)(1.0 / 255.0));
    }
    else

--- a/spinner.cpp
+++ b/spinner.cpp
@@ -386,7 +386,7 @@ void Spinner::RenderDynamic()
    if (image)
    {
       pd3dDevice->basicShader->SetTechniqueMetal(SHADER_TECHNIQUE_basic_with_texture, mat->m_bIsMetal);
-      pd3dDevice->basicShader->SetTexture(SHADER_Texture0, image, TextureFilter::TEXTURE_MODE_TRILINEAR, false, false, false);
+      pd3dDevice->basicShader->SetTexture(SHADER_tex_base_color, image, TextureFilter::TEXTURE_MODE_TRILINEAR, false, false, false);
       pd3dDevice->basicShader->SetAlphaTestValue(image->m_alphaTestValue * (float)(1.0 / 255.0));
    }
    else // No image by that name

--- a/spinner.cpp
+++ b/spinner.cpp
@@ -392,7 +392,7 @@ void Spinner::RenderDynamic()
    else // No image by that name
       pd3dDevice->basicShader->SetTechniqueMetal(SHADER_TECHNIQUE_basic_without_texture, mat->m_bIsMetal);
 
-   pd3dDevice->basicShader->Begin(0);
+   pd3dDevice->basicShader->Begin();
    pd3dDevice->DrawIndexedPrimitiveVB(RenderDevice::TRIANGLELIST, MY_D3DFVF_NOTEX2_VERTEX, m_plateVertexBuffer, 0, spinnerPlateNumVertices, m_plateIndexBuffer, 0, spinnerPlateNumFaces);
    pd3dDevice->basicShader->End();
 
@@ -475,7 +475,7 @@ void Spinner::RenderStatic()
    pd3dDevice->basicShader->SetTechniqueMetal(SHADER_TECHNIQUE_basic_without_texture, mat.m_bIsMetal);
    ppin3d->EnableAlphaBlend(false);
 
-   pd3dDevice->basicShader->Begin(0);
+   pd3dDevice->basicShader->Begin();
    pd3dDevice->DrawIndexedPrimitiveVB(RenderDevice::TRIANGLELIST, MY_D3DFVF_NOTEX2_VERTEX, m_bracketVertexBuffer, 0, spinnerBracketNumVertices, m_bracketIndexBuffer, 0, spinnerBracketNumFaces);
    pd3dDevice->basicShader->End();
 }

--- a/surface.cpp
+++ b/surface.cpp
@@ -1015,7 +1015,7 @@ void Surface::RenderSlingshots()
    pd3dDevice->SetRenderState(RenderDevice::ZWRITEENABLE, RenderDevice::RS_TRUE);
    pd3dDevice->SetRenderStateCulling(RenderDevice::CULL_NONE);
 
-   pd3dDevice->basicShader->Begin(0);
+   pd3dDevice->basicShader->Begin();
    for (size_t i = 0; i < m_vlinesling.size(); i++)
    {
       LineSegSlingshot * const plinesling = m_vlinesling[i];
@@ -1080,7 +1080,7 @@ void Surface::RenderWallsAtHeight(const bool drop)
          pd3dDevice->basicShader->SetTechniqueMetal(SHADER_TECHNIQUE_basic_without_texture, mat->m_bIsMetal);
 
       // combine drawcalls into one (hopefully faster)
-      pd3dDevice->basicShader->Begin(0);
+      pd3dDevice->basicShader->Begin();
       pd3dDevice->DrawIndexedPrimitiveVB(RenderDevice::TRIANGLELIST, MY_D3DFVF_NOTEX2_VERTEX, m_VBuffer, 0, m_numVertices * 4, m_IBuffer, 0, m_numVertices * 6);
       pd3dDevice->basicShader->End();
    }
@@ -1112,7 +1112,7 @@ void Surface::RenderWallsAtHeight(const bool drop)
          pd3dDevice->basicShader->SetTechniqueMetal(SHADER_TECHNIQUE_basic_without_texture, mat->m_bIsMetal);
 
       // Top
-      pd3dDevice->basicShader->Begin(0);
+      pd3dDevice->basicShader->Begin();
       pd3dDevice->DrawIndexedPrimitiveVB(RenderDevice::TRIANGLELIST, MY_D3DFVF_NOTEX2_VERTEX, m_VBuffer, m_numVertices * 4 + (!drop ? 0 : m_numVertices), m_numVertices, m_IBuffer, m_numVertices * 6, m_numPolys * 3);
       pd3dDevice->basicShader->End();
 
@@ -1124,7 +1124,7 @@ void Surface::RenderWallsAtHeight(const bool drop)
          else
             pd3dDevice->SetRenderStateCulling(RenderDevice::CULL_CW);
 
-         pd3dDevice->basicShader->Begin(0);
+         pd3dDevice->basicShader->Begin();
          pd3dDevice->DrawIndexedPrimitiveVB(RenderDevice::TRIANGLELIST, MY_D3DFVF_NOTEX2_VERTEX, m_VBuffer, m_numVertices * 4 + m_numVertices * 2, m_numVertices, m_IBuffer, m_numVertices * 6, m_numPolys * 3);
          pd3dDevice->basicShader->End();
       }

--- a/surface.cpp
+++ b/surface.cpp
@@ -1071,7 +1071,7 @@ void Surface::RenderWallsAtHeight(const bool drop)
       if (pinSide)
       {
          pd3dDevice->basicShader->SetTechniqueMetal(SHADER_TECHNIQUE_basic_with_texture, mat->m_bIsMetal);
-         pd3dDevice->basicShader->SetTexture(SHADER_Texture0, pinSide, TextureFilter::TEXTURE_MODE_TRILINEAR, false, false, false);
+         pd3dDevice->basicShader->SetTexture(SHADER_tex_base_color, pinSide, TextureFilter::TEXTURE_MODE_TRILINEAR, false, false, false);
          pd3dDevice->basicShader->SetAlphaTestValue(pinSide->m_alphaTestValue * (float)(1.0 / 255.0));
 
          //g_pplayer->m_pin3d.SetPrimaryTextureFilter( 0, TEXTURE_MODE_TRILINEAR );
@@ -1103,7 +1103,7 @@ void Surface::RenderWallsAtHeight(const bool drop)
       if (pin)
       {
          pd3dDevice->basicShader->SetTechniqueMetal(SHADER_TECHNIQUE_basic_with_texture, mat->m_bIsMetal);
-         pd3dDevice->basicShader->SetTexture(SHADER_Texture0, pin, TextureFilter::TEXTURE_MODE_TRILINEAR, false, false, false);
+         pd3dDevice->basicShader->SetTexture(SHADER_tex_base_color, pin, TextureFilter::TEXTURE_MODE_TRILINEAR, false, false, false);
          pd3dDevice->basicShader->SetAlphaTestValue(pin->m_alphaTestValue * (float)(1.0 / 255.0));
 
          //g_pplayer->m_pin3d.SetPrimaryTextureFilter( 0, TEXTURE_MODE_TRILINEAR );

--- a/trigger.cpp
+++ b/trigger.cpp
@@ -613,7 +613,7 @@ void Trigger::RenderDynamic()
    if (m_d.m_shape == TriggerWireA || m_d.m_shape == TriggerWireB || m_d.m_shape == TriggerWireC || m_d.m_shape == TriggerWireD || m_d.m_shape == TriggerInder)
       pd3dDevice->SetRenderStateCulling(RenderDevice::CULL_NONE);
 
-   pd3dDevice->basicShader->Begin(0);
+   pd3dDevice->basicShader->Begin();
    pd3dDevice->DrawIndexedPrimitiveVB(RenderDevice::TRIANGLELIST, MY_D3DFVF_NOTEX2_VERTEX, m_vertexBuffer, 0, m_numVertices, m_triggerIndexBuffer, 0, m_numIndices);
    pd3dDevice->basicShader->End();
 }

--- a/vpinball.cpp
+++ b/vpinball.cpp
@@ -407,8 +407,8 @@ void VPinball::ResetAllDockers()
 {
    const bool createNotes = m_dockNotes != nullptr;
    CloseAllDockers();
-   DeleteSubKey("Editor\\Dock Windows");
-   CreateDocker();
+   DeleteSubKey("Editor\\Dock Windows"s); // Old Win32xx
+   DeleteSubKey("Editor\\Dock Settings"s); // Win32xx 9+   CreateDocker();
    if (createNotes)
       GetDefaultNotesDocker();
 }


### PR DESCRIPTION
This large PR fixes a lot of problems I stumbled upon when starting to work on reimplementing the postprocess. So, despite the name of the branch, it does not contains postprocess yet (not AA, AO, and so on) but it will be far easier after the changes detailled below. Also, the rendering with the changes included in this PR moves one big step toward VPX rendering. On most table, I can not spot differences anymore.

### OpenGL shader cleanup
The ShaderGL.cpp file was quite messy and had a few bugs. It had 2 implementations mixed together through the TWEAK_GL switch. Since one of the 2 was 'legacy' (the one which was not tagged Tweak_GL), I removed it. I also cleaned up the complete class, resulting in a smaller an easier to maintain file.

Also  a few graphic glitch were caused by the fact that shader's samplers were not initialized, which is needed by OpenGL, so I added it (uninitialized samplers return vec4(0.0) for DirectX, not for OpenGL).

### Texture vs Sampler in OpenGL
First thing is that all OpenGL shaders were based on the directx shader **texture** identifiers instead of the **samplers** identifiers. This leads to quite a few (little) errors or differences. I don't know if there is a clear definition of texture vs samplers. For me, textures are the image (the data with their format) while the samplers are the tool to sample these data (texture reference but also clamping and filtering). The filtering really matters and makes quite a difference in rendering quality. DXEffect framework manages the links between texture and samplers. On OpenGL side it must be implemented.

What I did is to have a shared declaration of all uniforms and samplers in the c++ code (shader.h / shader.cpp) that gives all the needed informations (sampler name, associated DirectX texture name, default texture unit,...) and use this to reference the sampler & uniform elsewhere. This code can be pushed further later on by cleaning up the clamp/filter management, and the texture unit allocation. This was not strictly needed so it is not included in this PR.

### Static pre-rendering
VPX performs static prerendering to reach good performance. This is included in this PR, with a fairly more simple implementation that rely on the GPU. As far as I can tell, it runs faster and should work as-is also for DirectX. Since VPVR is missing the mirror rendering it is slightly tweaked regarding the depth buffer (i.e. include the depth of the playfield since VPVR does not have the static mirror with depth).

### VPX <-> VPVR sync
As usual the PR has somme minor cleanup to limit the difference between the codebases. It also contains the latest changes made to VPX up to commit https://github.com/vpinball/vpinball/commit/3290c74d88372dfba8f79ca246f5bce0a683ae7b

### What is missing
Still this PR was not made to fix the lastest issue linked to the rewrite of a large part of the rendering. So, the rendering has been tested on desktop and works really well (fairly better than before, faster thanks to static, and is finally matching VPX) but it was not tested in VR and is likely to have issue to be tackled (like https://github.com/vpinball/vpvr/issues/24 and https://github.com/vpinball/vpvr/issues/29). Still, since the changes are quite large, it would be worth testing. Also, beside bloom, this is still missing all the postprocess (AO, mirror, FXAA,...). Activating these options is likely to break the rendering.


_Note: The force push was an error I made with git and fix a merge conflict I incidentally committed..._