### PR TITLE
Sampler cleanup follow up

### DIFF
--- a/RenderDevice.h
+++ b/RenderDevice.h
@@ -1,5 +1,6 @@
 #pragma once
 
+#include <list>
 #include <inc/robin_hood.h>
 #include "typedefs3D.h"
 
@@ -426,7 +427,15 @@ private:
 
    VertexDeclaration *currentDeclaration; // for caching
 
+#ifdef ENABLE_SDL
+   static GLuint m_samplerStateCache[3 * 3 * 5];
+#endif
+
 public:
+#ifdef ENABLE_SDL
+   GLuint GetSamplerState(SamplerFilter filter, SamplerAddressMode clamp_u, SamplerAddressMode clamp_v);
+#endif
+
 #ifdef ENABLE_SDL
    GLfloat m_maxaniso;
    int m_GLversion;
@@ -489,6 +498,8 @@ public:
    //Shader* m_curShader; // for caching
 
    TextureManager m_texMan;
+
+   std::vector<SamplerBinding*> m_samplerBindings;
 
    static unsigned int m_stats_drawn_triangles;
 

--- a/RenderTarget.cpp
+++ b/RenderTarget.cpp
@@ -63,6 +63,13 @@ RenderTarget::RenderTarget(RenderDevice* rd, const int width, const int height, 
    glGenFramebuffers(1, &m_framebuffer);
    glBindFramebuffer(GL_FRAMEBUFFER, m_framebuffer);
 
+   // Update bind cache
+   auto tex_unit = m_rd->m_samplerBindings.back();
+   if (tex_unit->sampler != nullptr)
+      tex_unit->sampler->m_bindings.erase(tex_unit);
+   tex_unit->sampler = nullptr;
+   glActiveTexture(GL_TEXTURE0 + tex_unit->unit);
+
    if (nMSAASamples > 1)
    {
       glGenTextures(1, &m_color_tex);
@@ -264,6 +271,10 @@ void RenderTarget::Activate(bool ignoreStereo)
       return;
    currentFrameBuffer = this;
    currentStereoMode = ignoreStereo || m_is_back_buffer ? STEREO_OFF : m_stereo;
+   if (m_color_sampler)
+      m_color_sampler->Unbind();
+   if (m_depth_sampler)
+      m_depth_sampler->Unbind();
    glBindFramebuffer(GL_FRAMEBUFFER, m_framebuffer);
    if (m_is_back_buffer)
    {

--- a/RenderTarget.h
+++ b/RenderTarget.h
@@ -11,7 +11,7 @@ public:
    RenderTarget(RenderDevice* rd, const int width, const int height, const colorFormat format, bool with_depth, int nMSAASamples, StereoMode stereo, char* failureMessage);
    ~RenderTarget();
 
-   void Activate(bool ignoreStereo);
+   void Activate(const bool ignoreStereo);
 
    Sampler* GetColorSampler() { return m_color_sampler; }
    void UpdateDepthSampler();

--- a/Sampler.h
+++ b/Sampler.h
@@ -1,30 +1,37 @@
 #pragma once
 
+#include <set>
 #include "typedefs3D.h"
+
 class RenderDevice;
 
 enum SamplerFilter
 {
-   SF_UNDEFINED, // Used for undefined default values
    SF_NONE, // No filtering at all. DX: MIPFILTER = NONE; MAGFILTER = POINT; MINFILTER = POINT; / OpenGL Nearest/Nearest
    SF_POINT, // Point sampled (aka nearest mipmap) texture filtering.
    SF_BILINEAR, // Bilinar texture filtering (linear min/mag, no mipmapping). DX: MIPFILTER = NONE; MAGFILTER = LINEAR; MINFILTER = LINEAR;
    SF_TRILINEAR, // Trilinar texture filtering (linear min/mag, with mipmapping). DX: MIPFILTER = LINEAR; MAGFILTER = LINEAR; MINFILTER = LINEAR;
-   SF_ANISOTROPIC // Anisotropic texture filtering.
+   SF_ANISOTROPIC, // Anisotropic texture filtering.
+   SF_UNDEFINED, // Used for undefined default values
 };
 
 enum SamplerAddressMode
 {
-   SA_UNDEFINED, // Used for undefined default values
-#ifdef ENABLE_SDL
-   SA_REPEAT = GL_REPEAT,
-   SA_CLAMP = GL_CLAMP_TO_EDGE,
-   SA_MIRROR = GL_MIRRORED_REPEAT
-#else
    SA_REPEAT,
    SA_CLAMP,
-   SA_MIRROR
-#endif
+   SA_MIRROR,
+   SA_UNDEFINED, // Used for undefined default values
+};
+
+class Sampler;
+struct SamplerBinding
+{
+   int unit;
+   int use_rank;
+   Sampler* sampler;
+   SamplerFilter filter;
+   SamplerAddressMode clamp_u;
+   SamplerAddressMode clamp_v;
 };
 
 class Sampler
@@ -40,6 +47,7 @@ public:
 #endif
    ~Sampler();
 
+   void Unbind();
    void UpdateTexture(BaseTexture* const surf, const bool force_linear_rgb);
    void SetClamp(const SamplerAddressMode clampu, const SamplerAddressMode clampv);
    void SetFilter(const SamplerFilter filter);
@@ -54,6 +62,7 @@ public:
 
 public:
    bool m_dirty;
+   std::set<SamplerBinding*> m_bindings;
 
 private:
    bool m_ownTexture;

--- a/Shader.h
+++ b/Shader.h
@@ -301,6 +301,7 @@ private:
    static const ShaderUniform Shader::shaderUniformNames[SHADER_UNIFORM_COUNT];
    ShaderUniforms getUniformByName(const string& name);
    ShaderAttributes getAttributeByName(const string& name);
+   ShaderTechniques getTechniqueByName(const string& name);
 
 #ifdef ENABLE_SDL
    string m_shaderCodeName;
@@ -314,7 +315,7 @@ private:
    struct uniformLoc
    {
       GLenum type;
-      int location;
+      GLint location;
       int size;
       GLuint blockBuffer;
    };
@@ -322,7 +323,7 @@ private:
    {
       int index;
       string& name;
-      int program;
+      GLuint program;
       attributeLoc attributeLocation[SHADER_ATTRIBUTE_COUNT];
       uniformLoc uniformLocation[SHADER_UNIFORM_COUNT];
    };
@@ -332,7 +333,7 @@ private:
 #endif
    bool parseFile(const string& fileNameRoot, const string& fileName, int level, robin_hood::unordered_map<string, string>& values, const string& parentMode);
    string analyzeFunction(const char* shaderCodeName, const string& technique, const string& functionName, const robin_hood::unordered_map<string, string>& values);
-   ShaderTechnique* compileGLShader(const string& fileNameRoot, string& shaderCodeName, const string& vertex, const string& geometry, const string& fragment);
+   ShaderTechnique* compileGLShader(const ShaderTechniques technique, const string& fileNameRoot, string& shaderCodeName, const string& vertex, const string& geometry, const string& fragment);
 
    void ApplyUniform(const ShaderUniforms uniformName);
 
@@ -350,12 +351,11 @@ private:
       floatP fp; // uniform blocks
       Sampler* sampler; // texture samplers
    };
+   std::vector<ShaderUniforms> m_uniforms[SHADER_TECHNIQUE_COUNT];
    bool m_isCacheValid[SHADER_TECHNIQUE_COUNT];
    UniformCache m_uniformCache[SHADER_TECHNIQUE_COUNT + 1][SHADER_UNIFORM_COUNT];
-   
    ShaderTechnique* m_techniques[SHADER_TECHNIQUE_COUNT];
    ShaderTechniques m_technique;
-   int m_nextTextureSlot;
    Sampler* m_noTexture;
    static Matrix3D mWorld, mView, mProj[2];
 

--- a/pin/player.cpp
+++ b/pin/player.cpp
@@ -4915,7 +4915,7 @@ void Player::PrepareVideoBuffersAO()
    if (ss_refl)
    {
       SSRefl();
-      renderedRT = m_pin3d.m_pd3dPrimaryDevice->GetBackBufferTmpTexture2();
+      renderedRT = m_pin3d.m_pd3dPrimaryDevice->GetReflectionBufferTexture();
    }
 
    if (GetProfilingMode() == PF_ENABLED)


### PR DESCRIPTION
This PR contains 3 things:
- it moves to using OpenGL Sampler state. After researching, I think this is the only way to have the same sampling between VPX and VPVR since VPX sometimes uses the same texture for different samplers states (filtered/unfiltered). The default for OpenGL is to apply sampler state directly to texture object which prevents having different sampler from the same texture object. Luckily, sampler states were added to OpenGL 3.3 and allow to bind a texture with different sampler state. This is implemented and tested.
- texture caching: performance is not that good at the moment, so I added a simple priority queue texture cache that do the job and gives quite a few FPS.
- a little fix for SSR (which is not yet implemented and tested, but at least it won't crash everything)

I did quite a lot of tests on this. I also performed a full glsl validation of the generated shaders (which gives only harmless warnings). I hope it will be good and solve more bugs than it creates :)

Sampling should be mostly fixed now (it still needs anisotropy to be cleanly (re)implemented, a cleanup to remove all the sampler state duplication when calling setTexture, and a clean up of explicit state setting in RenderDevice but these 2 last have to be performed in sync with VPX, so after 10.7.2 is finalized).