### PR TITLE
Sampler filters

### DIFF
--- a/Sampler.h
+++ b/Sampler.h
@@ -37,12 +37,12 @@ struct SamplerBinding
 class Sampler
 {
 public:
-   Sampler(RenderDevice* rd, BaseTexture* const surf, const bool force_linear_rgb, const SamplerAddressMode clampu = SA_CLAMP, const SamplerAddressMode clampv = SA_CLAMP, const SamplerFilter filter = SF_NONE);
+   Sampler(RenderDevice* rd, BaseTexture* const surf, const bool force_linear_rgb, const SamplerAddressMode clampu = SA_UNDEFINED, const SamplerAddressMode clampv = SA_UNDEFINED, const SamplerFilter filter = SF_UNDEFINED);
 #ifdef ENABLE_SDL
-   Sampler(RenderDevice* rd, GLuint glTexture, bool ownTexture, bool isMSAA, bool force_linear_rgb, const SamplerAddressMode clampu = SA_CLAMP, const SamplerAddressMode clampv = SA_CLAMP, const SamplerFilter filter = SF_NONE);
+   Sampler(RenderDevice* rd, GLuint glTexture, bool ownTexture, bool isMSAA, bool force_linear_rgb, const SamplerAddressMode clampu = SA_UNDEFINED, const SamplerAddressMode clampv = SA_UNDEFINED, const SamplerFilter filter = SF_UNDEFINED);
    GLuint GetCoreTexture() const { return m_texture; }
 #else
-   Sampler(RenderDevice* rd, IDirect3DTexture9* dx9Texture, bool ownTexture, bool force_linear_rgb, const SamplerAddressMode clampu = SA_CLAMP, const SamplerAddressMode clampv = SA_CLAMP, const SamplerFilter filter = SF_NONE);
+   Sampler(RenderDevice* rd, IDirect3DTexture9* dx9Texture, bool ownTexture, bool force_linear_rgb, const SamplerAddressMode clampu = SA_UNDEFINED, const SamplerAddressMode clampv = SA_UNDEFINED, const SamplerFilter filter = SF_UNDEFINED);
    IDirect3DTexture9* GetCoreTexture() { return m_texture;  }
 #endif
    ~Sampler();

--- a/Shader.cpp
+++ b/Shader.cpp
@@ -149,8 +149,8 @@ const Shader::ShaderUniform Shader::shaderUniformNames[SHADER_UNIFORM_COUNT] {
    SHADER_SAMPLER(tex_dmd, texSampler0, Texture0, 0, SA_MIRROR, SA_MIRROR, SF_NONE), // DMD
    SHADER_SAMPLER(tex_sprite, texSampler1, Texture0, 0, SA_MIRROR, SA_MIRROR, SF_TRILINEAR), // Sprite
    // Flasher shader
-   SHADER_SAMPLER(tex_flasher_A, texSampler0, Texture0, 0, SA_UNDEFINED, SA_UNDEFINED, SF_UNDEFINED), // base texture
-   SHADER_SAMPLER(tex_flasher_B, texSampler1, Texture1, 1, SA_CLAMP, SA_CLAMP, SF_TRILINEAR), // texB
+   SHADER_SAMPLER(tex_flasher_A, texSampler0, Texture0, 0, SA_REPEAT, SA_REPEAT, SF_TRILINEAR), // base texture
+   SHADER_SAMPLER(tex_flasher_B, texSampler1, Texture1, 1, SA_REPEAT, SA_REPEAT, SF_TRILINEAR), // texB
    // FB shader
    SHADER_SAMPLER(tex_fb_unfiltered, texSampler4, Texture0, 0, SA_CLAMP, SA_CLAMP, SF_POINT), // Framebuffer (unfiltered)
    SHADER_SAMPLER(tex_fb_filtered, texSampler5, Texture0, 0, SA_CLAMP, SA_CLAMP, SF_BILINEAR), // Framebuffer (filtered)
@@ -161,18 +161,18 @@ const Shader::ShaderUniform Shader::shaderUniformNames[SHADER_UNIFORM_COUNT] {
    SHADER_SAMPLER(tex_color_lut, texSampler6, Texture4, 2, SA_CLAMP, SA_CLAMP, SF_BILINEAR), // Color grade LUT
    SHADER_SAMPLER(tex_ao_dither, texSamplerAOdither, Texture4, 3, SA_REPEAT, SA_REPEAT, SF_NONE), // AO dither
    // Ball shader
-   SHADER_SAMPLER(tex_ball_color, texSampler0, Texture0, 0, SA_UNDEFINED, SA_UNDEFINED, SF_UNDEFINED), // base texture
+   SHADER_SAMPLER(tex_ball_color, texSampler0, Texture0, 0, SA_REPEAT, SA_REPEAT, SF_TRILINEAR), // base texture
    SHADER_SAMPLER(tex_ball_playfield, texSampler1, Texture1, 1, SA_REPEAT, SA_REPEAT, SF_TRILINEAR), // playfield
    //SHADER_SAMPLER(tex_diffuse_env, texSampler2, Texture2, 2, SA_REPEAT, SA_CLAMP, SF_BILINEAR), // diffuse environment contribution/radiance [Shared with basic]
    SHADER_SAMPLER(tex_ball_decal, texSampler7, Texture3, 3, SA_REPEAT, SA_REPEAT, SF_TRILINEAR), // ball decal
    // Basic shader
-   SHADER_SAMPLER(tex_base_color, texSampler0, Texture0, 0, SA_UNDEFINED, SA_UNDEFINED, SF_UNDEFINED), // base texture
+   SHADER_SAMPLER(tex_base_color, texSampler0, Texture0, 0, SA_REPEAT, SA_REPEAT, SF_TRILINEAR), // base texture
    SHADER_SAMPLER(tex_env, texSampler1, Texture1, 1, SA_REPEAT, SA_CLAMP, SF_TRILINEAR), // environment
    SHADER_SAMPLER(tex_diffuse_env, texSampler2, Texture2, 2, SA_REPEAT, SA_CLAMP, SF_BILINEAR), // diffuse environment contribution/radiance
    SHADER_SAMPLER(tex_base_transmission, texSamplerBL, Texture3, 3, SA_CLAMP, SA_CLAMP, SF_BILINEAR), // bulb light/transmission buffer texture
-   SHADER_SAMPLER(tex_base_normalmap, texSamplerN, Texture4, 4, SA_UNDEFINED, SA_UNDEFINED, SF_UNDEFINED), // normal map texture
+   SHADER_SAMPLER(tex_base_normalmap, texSamplerN, Texture4, 4, SA_REPEAT, SA_REPEAT, SF_TRILINEAR), // normal map texture
    // Classic light shader
-   SHADER_SAMPLER(tex_light_color, texSampler0, Texture0, 0, SA_UNDEFINED, SA_UNDEFINED, SF_UNDEFINED), // base texture
+   SHADER_SAMPLER(tex_light_color, texSampler0, Texture0, 0, SA_REPEAT, SA_REPEAT, SF_TRILINEAR), // base texture
    // SHADER_SAMPLER(tex_env, texSampler1, Texture1, 1, SA_REPEAT, SA_CLAMP, SF_TRILINEAR), // environment [Shared with basic]
    // SHADER_SAMPLER(tex_diffuse_env, texSampler2, Texture2, 2, SA_REPEAT, SA_CLAMP, SF_BILINEAR), // diffuse environment contribution/radiance [Shared with basic]
    // Stereo shader (VPVR only, combine the 2 rendered eyes into a single one)

--- a/Shader.h
+++ b/Shader.h
@@ -229,7 +229,8 @@ public:
    void Begin();
    void End();
 
-   void SetTexture(const ShaderUniforms texelName, Texture* texel, const TextureFilter filter, const bool clampU, const bool clampV, const bool force_linear_rgb);
+   void SetTexture(const ShaderUniforms texelName, BaseTexture* texel, const SamplerFilter filter = SF_UNDEFINED, const SamplerAddressMode clampU = SA_UNDEFINED, const SamplerAddressMode clampV = SA_UNDEFINED, const bool force_linear_rgb = false);
+   void SetTexture(const ShaderUniforms texelName, Texture* texel, const SamplerFilter filter = SF_UNDEFINED, const SamplerAddressMode clampU = SA_UNDEFINED, const SamplerAddressMode clampV = SA_UNDEFINED, const bool force_linear_rgb = false);
    void SetTexture(const ShaderUniforms texelName, Sampler* texel);
    void SetTextureNull(const ShaderUniforms texelName);
    void SetMaterial(const Material * const mat);

--- a/Shader.h
+++ b/Shader.h
@@ -156,8 +156,8 @@ enum ShaderUniforms
    SHADER_SAMPLER(tex_dmd, texSampler0, Texture0, 0, SA_MIRROR, SA_MIRROR, SF_NONE), // DMD
    SHADER_SAMPLER(tex_sprite, texSampler1, Texture0, 0, SA_MIRROR, SA_MIRROR, SF_TRILINEAR), // Sprite
    // Flasher shader
-   SHADER_SAMPLER(tex_flasher_A, texSampler0, Texture0, 0, SA_UNDEFINED, SA_UNDEFINED, SF_UNDEFINED), // base texture
-   SHADER_SAMPLER(tex_flasher_B, texSampler1, Texture1, 1, SA_CLAMP, SA_CLAMP, SF_TRILINEAR), // texB
+   SHADER_SAMPLER(tex_flasher_A, texSampler0, Texture0, 0, SA_REPEAT, SA_REPEAT, SF_TRILINEAR), // base texture
+   SHADER_SAMPLER(tex_flasher_B, texSampler1, Texture1, 1, SA_REPEAT, SA_REPEAT, SF_TRILINEAR), // texB
    // FB shader
    SHADER_SAMPLER(tex_fb_unfiltered, texSampler4, Texture0, 0, SA_CLAMP, SA_CLAMP, SF_POINT), // Framebuffer (unfiltered)
    SHADER_SAMPLER(tex_fb_filtered, texSampler5, Texture0, 0, SA_CLAMP, SA_CLAMP, SF_BILINEAR), // Framebuffer (filtered)
@@ -168,18 +168,18 @@ enum ShaderUniforms
    SHADER_SAMPLER(tex_color_lut, texSampler6, Texture4, 2, SA_CLAMP, SA_CLAMP, SF_BILINEAR), // Color grade LUT
    SHADER_SAMPLER(tex_ao_dither, texSamplerAOdither, Texture4, 3, SA_REPEAT, SA_REPEAT, SF_NONE), // AO dither
    // Ball shader
-   SHADER_SAMPLER(tex_ball_color, texSampler0, Texture0, 0, SA_UNDEFINED, SA_UNDEFINED, SF_UNDEFINED), // base texture
+   SHADER_SAMPLER(tex_ball_color, texSampler0, Texture0, 0, SA_REPEAT, SA_REPEAT, SF_TRILINEAR), // base texture
    SHADER_SAMPLER(tex_ball_playfield, texSampler1, Texture1, 1, SA_REPEAT, SA_REPEAT, SF_TRILINEAR), // playfield
    //SHADER_SAMPLER(tex_diffuse_env, texSampler2, Texture2, 2, SA_REPEAT, SA_CLAMP, SF_BILINEAR), // diffuse environment contribution/radiance [Shared with basic]
    SHADER_SAMPLER(tex_ball_decal, texSampler7, Texture3, 3, SA_REPEAT, SA_REPEAT, SF_TRILINEAR), // ball decal
    // Basic shader
-   SHADER_SAMPLER(tex_base_color, texSampler0, Texture0, 0, SA_UNDEFINED, SA_UNDEFINED, SF_UNDEFINED), // base texture
+   SHADER_SAMPLER(tex_base_color, texSampler0, Texture0, 0, SA_REPEAT, SA_REPEAT, SF_TRILINEAR), // base texture
    SHADER_SAMPLER(tex_env, texSampler1, Texture1, 1, SA_REPEAT, SA_CLAMP, SF_TRILINEAR), // environment
    SHADER_SAMPLER(tex_diffuse_env, texSampler2, Texture2, 2, SA_REPEAT, SA_CLAMP, SF_BILINEAR), // diffuse environment contribution/radiance
    SHADER_SAMPLER(tex_base_transmission, texSamplerBL, Texture3, 3, SA_CLAMP, SA_CLAMP, SF_BILINEAR), // bulb light/transmission buffer texture
-   SHADER_SAMPLER(tex_base_normalmap, texSamplerN, Texture4, 4, SA_UNDEFINED, SA_UNDEFINED, SF_UNDEFINED), // normal map texture
+   SHADER_SAMPLER(tex_base_normalmap, texSamplerN, Texture4, 4, SA_REPEAT, SA_REPEAT, SF_TRILINEAR), // normal map texture
    // Classic light shader
-   SHADER_SAMPLER(tex_light_color, texSampler0, Texture0, 0, SA_UNDEFINED, SA_UNDEFINED, SF_UNDEFINED), // base texture
+   SHADER_SAMPLER(tex_light_color, texSampler0, Texture0, 0, SA_REPEAT, SA_REPEAT, SF_TRILINEAR), // base texture
    // SHADER_SAMPLER(tex_env, texSampler1, Texture1, 1, SA_REPEAT, SA_CLAMP, SF_TRILINEAR), // environment [Shared with basic]
    // SHADER_SAMPLER(tex_diffuse_env, texSampler2, Texture2, 2, SA_REPEAT, SA_CLAMP, SF_BILINEAR), // diffuse environment contribution/radiance [Shared with basic]
    // Stereo shader (VPVR only, combine the 2 rendered eyes into a single one)

--- a/ShaderGL.cpp
+++ b/ShaderGL.cpp
@@ -582,10 +582,7 @@ void Shader::SetTextureNull(const ShaderUniforms texelName) {
 
 void Shader::SetTexture(const ShaderUniforms texelName, Texture* texel, const SamplerFilter filter, const SamplerAddressMode clampU, const SamplerAddressMode clampV, const bool force_linear_rgb)
 {
-   if (!texel || !texel->m_pdsBuffer)
-      SetTexture(texelName, (Sampler*)nullptr);
-   else
-      SetTexture(texelName, m_renderDevice->m_texMan.LoadTexture(texel->m_pdsBuffer, filter, clampU, clampV, force_linear_rgb));
+   SetTexture(texelName, texel->m_pdsBuffer, filter, clampU, clampV, force_linear_rgb);
 }
 
 void Shader::SetTexture(const ShaderUniforms texelName, BaseTexture* texel, const SamplerFilter filter, const SamplerAddressMode clampU, const SamplerAddressMode clampV, const bool force_linear_rgb)
@@ -831,9 +828,9 @@ void Shader::ApplyUniform(const ShaderUniforms uniformName)
       }
       else
       {
-         auto filter = shaderUniformNames[uniformName].default_filter;
-         auto clampu = shaderUniformNames[uniformName].default_clampu;
-         auto clampv = shaderUniformNames[uniformName].default_clampv;
+         SamplerFilter filter = shaderUniformNames[uniformName].default_filter;
+         SamplerAddressMode clampu = shaderUniformNames[uniformName].default_clampu;
+         SamplerAddressMode clampv = shaderUniformNames[uniformName].default_clampv;
          if (filter == SF_UNDEFINED)
             filter = texel->GetFilter();
          if (clampu == SA_UNDEFINED)

--- a/ShaderGL.cpp
+++ b/ShaderGL.cpp
@@ -577,15 +577,23 @@ void Shader::SetTechniqueMetal(ShaderTechniques _technique, const bool isMetal)
 }
 
 void Shader::SetTextureNull(const ShaderUniforms texelName) {
-   SetTexture(texelName, nullptr);
+   SetTexture(texelName, (Sampler*) nullptr);
 }
 
-void Shader::SetTexture(const ShaderUniforms texelName, Texture* texel, const TextureFilter filter, const bool clampU, const bool clampV, const bool force_linear_rgb)
+void Shader::SetTexture(const ShaderUniforms texelName, Texture* texel, const SamplerFilter filter, const SamplerAddressMode clampU, const SamplerAddressMode clampV, const bool force_linear_rgb)
 {
    if (!texel || !texel->m_pdsBuffer)
-      SetTexture(texelName, nullptr);
+      SetTexture(texelName, (Sampler*)nullptr);
    else
       SetTexture(texelName, m_renderDevice->m_texMan.LoadTexture(texel->m_pdsBuffer, filter, clampU, clampV, force_linear_rgb));
+}
+
+void Shader::SetTexture(const ShaderUniforms texelName, BaseTexture* texel, const SamplerFilter filter, const SamplerAddressMode clampU, const SamplerAddressMode clampV, const bool force_linear_rgb)
+{
+   if (!texel)
+      SetTexture(texelName, (Sampler*)nullptr);
+   else
+      SetTexture(texelName, m_renderDevice->m_texMan.LoadTexture(texel, filter, clampU, clampV, force_linear_rgb));
 }
 
 void Shader::SetTexture(const ShaderUniforms texelName, Sampler* texel)

--- a/TextureManager.cpp
+++ b/TextureManager.cpp
@@ -5,7 +5,7 @@
 #include "Texture.h"
 #include "typedefs3D.h"
 
-Sampler* TextureManager::LoadTexture(BaseTexture* memtex, const TextureFilter filter, const bool clampU, const bool clampV, const bool force_linear_rgb)
+Sampler* TextureManager::LoadTexture(BaseTexture* memtex, const SamplerFilter filter, const SamplerAddressMode clampU, const SamplerAddressMode clampV, const bool force_linear_rgb)
 {
    SamplerFilter sa_filter;
    switch (filter)

--- a/TextureManager.cpp
+++ b/TextureManager.cpp
@@ -7,29 +7,10 @@
 
 Sampler* TextureManager::LoadTexture(BaseTexture* memtex, const SamplerFilter filter, const SamplerAddressMode clampU, const SamplerAddressMode clampV, const bool force_linear_rgb)
 {
-   SamplerFilter sa_filter;
-   switch (filter)
-   {
-   case TEXTURE_MODE_NONE:
-      sa_filter = SF_NONE;
-      break;
-   case TEXTURE_MODE_POINT:
-      sa_filter = SF_POINT;
-      break;
-   case TEXTURE_MODE_BILINEAR:
-      sa_filter = SF_BILINEAR;
-      break;
-   case TEXTURE_MODE_TRILINEAR:
-      sa_filter = SF_TRILINEAR;
-      break;
-   case TEXTURE_MODE_ANISOTROPIC:
-      sa_filter = SF_ANISOTROPIC;
-      break;
-   }
    const Iter it = m_map.find(memtex);
    if (it == m_map.end())
    {
-      Sampler* sampler = new Sampler(&m_rd, memtex, force_linear_rgb, clampU ? SA_CLAMP : SA_REPEAT, clampV ? SA_CLAMP : SA_REPEAT, sa_filter);
+      Sampler* sampler = new Sampler(&m_rd, memtex, force_linear_rgb, clampU, clampV, filter);
       sampler->m_dirty = false;
       m_map[memtex] = sampler;
       return sampler;
@@ -42,8 +23,8 @@ Sampler* TextureManager::LoadTexture(BaseTexture* memtex, const SamplerFilter fi
          sampler->UpdateTexture(memtex, force_linear_rgb);
          sampler->m_dirty = false;
       }
-      sampler->SetClamp(clampU ? SA_CLAMP : SA_REPEAT, clampV ? SA_CLAMP : SA_REPEAT);
-      sampler->SetFilter(sa_filter);
+      sampler->SetClamp(clampU, clampV);
+      sampler->SetFilter(filter);
       return sampler;
    }
 }

--- a/TextureManager.h
+++ b/TextureManager.h
@@ -21,7 +21,7 @@ public:
       UnloadAll();
    }
 
-   Sampler* LoadTexture(BaseTexture* memtex, const TextureFilter filter, const bool clampU, const bool clampV, const bool force_linear_rgb);
+   Sampler* LoadTexture(BaseTexture* memtex, const SamplerFilter filter, const SamplerAddressMode clampU, const SamplerAddressMode clampV, const bool force_linear_rgb);
    void SetDirty(BaseTexture* memtex);
    void UnloadTexture(BaseTexture* memtex);
    void UnloadAll();

--- a/backGlass.cpp
+++ b/backGlass.cpp
@@ -162,7 +162,7 @@ BackGlass::BackGlass(RenderDevice* const pd3dDevice, Texture * backgroundFallbac
                   }
                   size_t size = decode_base64(attrib->value(), data, attrib->value_size(), data_len);
                   if ((size > 0) && (strcmp(imagesNode->name(), "BackglassImage") == 0)) {
-                     m_backgroundTexture = m_pd3dDevice->m_texMan.LoadTexture(BaseTexture::CreateFromData(data, size), TextureFilter::TEXTURE_MODE_TRILINEAR, true, true, false);
+                     m_backgroundTexture = m_pd3dDevice->m_texMan.LoadTexture(BaseTexture::CreateFromData(data, size), SF_TRILINEAR, SA_CLAMP, SA_CLAMP, false);
                      m_backglass_width = m_backgroundTexture->GetWidth();
                      m_backglass_height = m_backgroundTexture->GetHeight();
                   }
@@ -212,7 +212,7 @@ void BackGlass::Render()
 {
    if (g_pplayer->m_capPUP && capturePUP())
    {
-      m_backgroundTexture = m_pd3dDevice->m_texMan.LoadTexture(g_pplayer->m_texPUP, TextureFilter::TEXTURE_MODE_TRILINEAR, true, true, false);
+      m_backgroundTexture = m_pd3dDevice->m_texMan.LoadTexture(g_pplayer->m_texPUP, SF_TRILINEAR, SA_CLAMP, SA_CLAMP, false);
       m_backglass_width = g_pplayer->m_texPUP->width();
       m_backglass_height = g_pplayer->m_texPUP->height();
       float tableWidth, glassHeight;
@@ -241,7 +241,7 @@ void BackGlass::Render()
    if (m_backgroundTexture)
       m_pd3dDevice->DMDShader->SetTexture(SHADER_tex_sprite, m_backgroundTexture);
    else if (m_backgroundFallback)
-      m_pd3dDevice->DMDShader->SetTexture(SHADER_tex_sprite, m_backgroundFallback, TextureFilter::TEXTURE_MODE_TRILINEAR, true, true, false);
+      m_pd3dDevice->DMDShader->SetTexture(SHADER_tex_sprite, m_backgroundFallback, SF_TRILINEAR, SA_CLAMP, SA_CLAMP, false);
    else return;
 
    m_pd3dDevice->SetRenderState(RenderDevice::ZWRITEENABLE, RenderDevice::RS_FALSE);
@@ -292,7 +292,7 @@ void BackGlass::DMDdraw(float DMDposx, float DMDposy, float DMDwidth, float DMDh
          m_pd3dDevice->DMDShader->SetTechnique(SHADER_TECHNIQUE_basic_DMD_ext);
 
       if (g_pplayer->m_texdmd != nullptr)
-         m_pd3dDevice->DMDShader->SetTexture(SHADER_tex_dmd, m_pd3dDevice->m_texMan.LoadTexture(g_pplayer->m_texdmd, TextureFilter::TEXTURE_MODE_NONE, true, true, false));
+         m_pd3dDevice->DMDShader->SetTexture(SHADER_tex_dmd, g_pplayer->m_texdmd, SF_NONE, SA_CLAMP, SA_CLAMP, false);
       //      m_pd3dPrimaryDevice->DMDShader->SetVector(SHADER_quadOffsetScale, 0.0f, -1.0f, backglass_scale, backglass_scale*(float)backglass_height / (float)backglass_width);
       bool zDisabled = false;
       m_pd3dDevice->SetRenderStateCulling(RenderDevice::CULL_NONE);

--- a/backGlass.cpp
+++ b/backGlass.cpp
@@ -241,7 +241,7 @@ void BackGlass::Render()
    if (m_backgroundTexture)
       m_pd3dDevice->DMDShader->SetTexture(SHADER_tex_sprite, m_backgroundTexture);
    else if (m_backgroundFallback)
-      m_pd3dDevice->DMDShader->SetTexture(SHADER_tex_sprite, m_backgroundFallback, SF_TRILINEAR, SA_CLAMP, SA_CLAMP, false);
+      m_pd3dDevice->DMDShader->SetTexture(SHADER_tex_sprite, m_backgroundFallback, SF_TRILINEAR, SA_CLAMP, SA_CLAMP);
    else return;
 
    m_pd3dDevice->SetRenderState(RenderDevice::ZWRITEENABLE, RenderDevice::RS_FALSE);
@@ -292,7 +292,7 @@ void BackGlass::DMDdraw(float DMDposx, float DMDposy, float DMDwidth, float DMDh
          m_pd3dDevice->DMDShader->SetTechnique(SHADER_TECHNIQUE_basic_DMD_ext);
 
       if (g_pplayer->m_texdmd != nullptr)
-         m_pd3dDevice->DMDShader->SetTexture(SHADER_tex_dmd, g_pplayer->m_texdmd, SF_NONE, SA_CLAMP, SA_CLAMP, false);
+         m_pd3dDevice->DMDShader->SetTexture(SHADER_tex_dmd, g_pplayer->m_texdmd, SF_NONE, SA_CLAMP, SA_CLAMP);
       //      m_pd3dPrimaryDevice->DMDShader->SetVector(SHADER_quadOffsetScale, 0.0f, -1.0f, backglass_scale, backglass_scale*(float)backglass_height / (float)backglass_width);
       bool zDisabled = false;
       m_pd3dDevice->SetRenderStateCulling(RenderDevice::CULL_NONE);

--- a/bumper.cpp
+++ b/bumper.cpp
@@ -297,7 +297,7 @@ void Bumper::RenderBase(const Material * const baseMaterial)
    RenderDevice * const pd3dDevice = g_pplayer->m_pin3d.m_pd3dPrimaryDevice;
 
    pd3dDevice->basicShader->SetMaterial(baseMaterial);
-   pd3dDevice->basicShader->SetTexture(SHADER_tex_base_color, &m_baseTexture, SF_TRILINEAR, SA_REPEAT, SA_REPEAT, false);
+   pd3dDevice->basicShader->SetTexture(SHADER_tex_base_color, &m_baseTexture, SF_TRILINEAR, SA_REPEAT, SA_REPEAT);
    g_pplayer->m_pin3d.EnableAlphaBlend(false);
    pd3dDevice->basicShader->SetAlphaTestValue((float)(1.0 / 255.0));
 
@@ -311,7 +311,7 @@ void Bumper::RenderSocket(const Material * const socketMaterial)
    RenderDevice * const pd3dDevice = g_pplayer->m_pin3d.m_pd3dPrimaryDevice;
 
    pd3dDevice->basicShader->SetMaterial(socketMaterial);
-   pd3dDevice->basicShader->SetTexture(SHADER_tex_base_color, &m_skirtTexture, SF_TRILINEAR, SA_REPEAT, SA_REPEAT, false);
+   pd3dDevice->basicShader->SetTexture(SHADER_tex_base_color, &m_skirtTexture, SF_TRILINEAR, SA_REPEAT, SA_REPEAT);
    g_pplayer->m_pin3d.EnableAlphaBlend(false);
    pd3dDevice->basicShader->SetAlphaTestValue((float)(1.0 / 255.0));
 
@@ -325,7 +325,7 @@ void Bumper::RenderCap(const Material * const capMaterial)
    RenderDevice * const pd3dDevice = g_pplayer->m_pin3d.m_pd3dPrimaryDevice;
 
    pd3dDevice->basicShader->SetMaterial(capMaterial);
-   pd3dDevice->basicShader->SetTexture(SHADER_tex_base_color, &m_capTexture, SF_TRILINEAR, SA_REPEAT, SA_REPEAT, false);
+   pd3dDevice->basicShader->SetTexture(SHADER_tex_base_color, &m_capTexture, SF_TRILINEAR, SA_REPEAT, SA_REPEAT);
    g_pplayer->m_pin3d.EnableAlphaBlend(false);
    pd3dDevice->basicShader->SetAlphaTestValue((float)(1.0 / 255.0));
 
@@ -462,7 +462,7 @@ void Bumper::RenderDynamic()
       }
 
       pd3dDevice->basicShader->SetTechniqueMetal(SHADER_TECHNIQUE_basic_with_texture, ringMaterial.m_bIsMetal);
-      pd3dDevice->basicShader->SetTexture(SHADER_tex_base_color, &m_ringTexture, SF_TRILINEAR, SA_REPEAT, SA_REPEAT, false);
+      pd3dDevice->basicShader->SetTexture(SHADER_tex_base_color, &m_ringTexture, SF_TRILINEAR, SA_REPEAT, SA_REPEAT);
       pd3dDevice->basicShader->SetMaterial(&ringMaterial);
       pd3dDevice->basicShader->SetAlphaTestValue(-1.0f);
 
@@ -499,7 +499,7 @@ void Bumper::RenderDynamic()
       }
 
       const Material * const mat = m_ptable->GetMaterial(m_d.m_szSkirtMaterial);
-      pd3dDevice->basicShader->SetTexture(SHADER_tex_base_color, &m_skirtTexture, SF_TRILINEAR, SA_REPEAT, SA_REPEAT, false);
+      pd3dDevice->basicShader->SetTexture(SHADER_tex_base_color, &m_skirtTexture, SF_TRILINEAR, SA_REPEAT, SA_REPEAT);
       pd3dDevice->basicShader->SetTechniqueMetal(SHADER_TECHNIQUE_basic_with_texture, mat->m_bIsMetal);
       pd3dDevice->SetRenderStateCulling(RenderDevice::CULL_NONE);
       RenderSocket(mat);

--- a/bumper.cpp
+++ b/bumper.cpp
@@ -297,7 +297,7 @@ void Bumper::RenderBase(const Material * const baseMaterial)
    RenderDevice * const pd3dDevice = g_pplayer->m_pin3d.m_pd3dPrimaryDevice;
 
    pd3dDevice->basicShader->SetMaterial(baseMaterial);
-   pd3dDevice->basicShader->SetTexture(SHADER_tex_base_color, &m_baseTexture, SF_TRILINEAR, SA_REPEAT, SA_REPEAT);
+   pd3dDevice->basicShader->SetTexture(SHADER_tex_base_color, &m_baseTexture);
    g_pplayer->m_pin3d.EnableAlphaBlend(false);
    pd3dDevice->basicShader->SetAlphaTestValue((float)(1.0 / 255.0));
 
@@ -311,7 +311,7 @@ void Bumper::RenderSocket(const Material * const socketMaterial)
    RenderDevice * const pd3dDevice = g_pplayer->m_pin3d.m_pd3dPrimaryDevice;
 
    pd3dDevice->basicShader->SetMaterial(socketMaterial);
-   pd3dDevice->basicShader->SetTexture(SHADER_tex_base_color, &m_skirtTexture, SF_TRILINEAR, SA_REPEAT, SA_REPEAT);
+   pd3dDevice->basicShader->SetTexture(SHADER_tex_base_color, &m_skirtTexture);
    g_pplayer->m_pin3d.EnableAlphaBlend(false);
    pd3dDevice->basicShader->SetAlphaTestValue((float)(1.0 / 255.0));
 
@@ -325,7 +325,7 @@ void Bumper::RenderCap(const Material * const capMaterial)
    RenderDevice * const pd3dDevice = g_pplayer->m_pin3d.m_pd3dPrimaryDevice;
 
    pd3dDevice->basicShader->SetMaterial(capMaterial);
-   pd3dDevice->basicShader->SetTexture(SHADER_tex_base_color, &m_capTexture, SF_TRILINEAR, SA_REPEAT, SA_REPEAT);
+   pd3dDevice->basicShader->SetTexture(SHADER_tex_base_color, &m_capTexture);
    g_pplayer->m_pin3d.EnableAlphaBlend(false);
    pd3dDevice->basicShader->SetAlphaTestValue((float)(1.0 / 255.0));
 
@@ -462,7 +462,7 @@ void Bumper::RenderDynamic()
       }
 
       pd3dDevice->basicShader->SetTechniqueMetal(SHADER_TECHNIQUE_basic_with_texture, ringMaterial.m_bIsMetal);
-      pd3dDevice->basicShader->SetTexture(SHADER_tex_base_color, &m_ringTexture, SF_TRILINEAR, SA_REPEAT, SA_REPEAT);
+      pd3dDevice->basicShader->SetTexture(SHADER_tex_base_color, &m_ringTexture);
       pd3dDevice->basicShader->SetMaterial(&ringMaterial);
       pd3dDevice->basicShader->SetAlphaTestValue(-1.0f);
 
@@ -499,7 +499,7 @@ void Bumper::RenderDynamic()
       }
 
       const Material * const mat = m_ptable->GetMaterial(m_d.m_szSkirtMaterial);
-      pd3dDevice->basicShader->SetTexture(SHADER_tex_base_color, &m_skirtTexture, SF_TRILINEAR, SA_REPEAT, SA_REPEAT);
+      pd3dDevice->basicShader->SetTexture(SHADER_tex_base_color, &m_skirtTexture);
       pd3dDevice->basicShader->SetTechniqueMetal(SHADER_TECHNIQUE_basic_with_texture, mat->m_bIsMetal);
       pd3dDevice->SetRenderStateCulling(RenderDevice::CULL_NONE);
       RenderSocket(mat);

--- a/bumper.cpp
+++ b/bumper.cpp
@@ -297,7 +297,7 @@ void Bumper::RenderBase(const Material * const baseMaterial)
    RenderDevice * const pd3dDevice = g_pplayer->m_pin3d.m_pd3dPrimaryDevice;
 
    pd3dDevice->basicShader->SetMaterial(baseMaterial);
-   pd3dDevice->basicShader->SetTexture(SHADER_tex_base_color, &m_baseTexture, TextureFilter::TEXTURE_MODE_TRILINEAR, false, false, false);
+   pd3dDevice->basicShader->SetTexture(SHADER_tex_base_color, &m_baseTexture, SF_TRILINEAR, SA_REPEAT, SA_REPEAT, false);
    g_pplayer->m_pin3d.EnableAlphaBlend(false);
    pd3dDevice->basicShader->SetAlphaTestValue((float)(1.0 / 255.0));
 
@@ -311,7 +311,7 @@ void Bumper::RenderSocket(const Material * const socketMaterial)
    RenderDevice * const pd3dDevice = g_pplayer->m_pin3d.m_pd3dPrimaryDevice;
 
    pd3dDevice->basicShader->SetMaterial(socketMaterial);
-   pd3dDevice->basicShader->SetTexture(SHADER_tex_base_color, &m_skirtTexture, TextureFilter::TEXTURE_MODE_TRILINEAR, false, false, false);
+   pd3dDevice->basicShader->SetTexture(SHADER_tex_base_color, &m_skirtTexture, SF_TRILINEAR, SA_REPEAT, SA_REPEAT, false);
    g_pplayer->m_pin3d.EnableAlphaBlend(false);
    pd3dDevice->basicShader->SetAlphaTestValue((float)(1.0 / 255.0));
 
@@ -325,7 +325,7 @@ void Bumper::RenderCap(const Material * const capMaterial)
    RenderDevice * const pd3dDevice = g_pplayer->m_pin3d.m_pd3dPrimaryDevice;
 
    pd3dDevice->basicShader->SetMaterial(capMaterial);
-   pd3dDevice->basicShader->SetTexture(SHADER_tex_base_color, &m_capTexture, TextureFilter::TEXTURE_MODE_TRILINEAR, false, false, false);
+   pd3dDevice->basicShader->SetTexture(SHADER_tex_base_color, &m_capTexture, SF_TRILINEAR, SA_REPEAT, SA_REPEAT, false);
    g_pplayer->m_pin3d.EnableAlphaBlend(false);
    pd3dDevice->basicShader->SetAlphaTestValue((float)(1.0 / 255.0));
 
@@ -462,7 +462,7 @@ void Bumper::RenderDynamic()
       }
 
       pd3dDevice->basicShader->SetTechniqueMetal(SHADER_TECHNIQUE_basic_with_texture, ringMaterial.m_bIsMetal);
-      pd3dDevice->basicShader->SetTexture(SHADER_tex_base_color, &m_ringTexture, TextureFilter::TEXTURE_MODE_TRILINEAR, false, false, false);
+      pd3dDevice->basicShader->SetTexture(SHADER_tex_base_color, &m_ringTexture, SF_TRILINEAR, SA_REPEAT, SA_REPEAT, false);
       pd3dDevice->basicShader->SetMaterial(&ringMaterial);
       pd3dDevice->basicShader->SetAlphaTestValue(-1.0f);
 
@@ -499,7 +499,7 @@ void Bumper::RenderDynamic()
       }
 
       const Material * const mat = m_ptable->GetMaterial(m_d.m_szSkirtMaterial);
-      pd3dDevice->basicShader->SetTexture(SHADER_tex_base_color, &m_skirtTexture, TextureFilter::TEXTURE_MODE_TRILINEAR, false, false, false);
+      pd3dDevice->basicShader->SetTexture(SHADER_tex_base_color, &m_skirtTexture, SF_TRILINEAR, SA_REPEAT, SA_REPEAT, false);
       pd3dDevice->basicShader->SetTechniqueMetal(SHADER_TECHNIQUE_basic_with_texture, mat->m_bIsMetal);
       pd3dDevice->SetRenderStateCulling(RenderDevice::CULL_NONE);
       RenderSocket(mat);

--- a/decal.cpp
+++ b/decal.cpp
@@ -541,7 +541,7 @@ void Decal::RenderObject()
          pd3dDevice->basicShader->SetTechniqueMetal(SHADER_TECHNIQUE_basic_with_texture, mat->m_bIsMetal);
       else
          pd3dDevice->basicShader->SetTechnique(SHADER_TECHNIQUE_bg_decal_with_texture);
-      pd3dDevice->basicShader->SetTexture(SHADER_tex_base_color, pd3dDevice->m_texMan.LoadTexture(m_textImg, TextureFilter::TEXTURE_MODE_TRILINEAR, false, false, false));
+      pd3dDevice->basicShader->SetTexture(SHADER_tex_base_color, m_textImg, SF_TRILINEAR, SA_REPEAT, SA_REPEAT, false);
       pd3dDevice->basicShader->SetAlphaTestValue(-1.0f);
    }
    else
@@ -553,7 +553,7 @@ void Decal::RenderObject()
             pd3dDevice->basicShader->SetTechniqueMetal(SHADER_TECHNIQUE_basic_with_texture, mat->m_bIsMetal);
          else
             pd3dDevice->basicShader->SetTechnique(SHADER_TECHNIQUE_bg_decal_with_texture);
-         pd3dDevice->basicShader->SetTexture(SHADER_tex_base_color, pin, TextureFilter::TEXTURE_MODE_TRILINEAR, false, false, false);
+         pd3dDevice->basicShader->SetTexture(SHADER_tex_base_color, pin, SF_TRILINEAR, SA_REPEAT, SA_REPEAT, false);
          pd3dDevice->basicShader->SetAlphaTestValue(pin->m_alphaTestValue * (float)(1.0 / 255.0));
       }
       else

--- a/decal.cpp
+++ b/decal.cpp
@@ -541,7 +541,7 @@ void Decal::RenderObject()
          pd3dDevice->basicShader->SetTechniqueMetal(SHADER_TECHNIQUE_basic_with_texture, mat->m_bIsMetal);
       else
          pd3dDevice->basicShader->SetTechnique(SHADER_TECHNIQUE_bg_decal_with_texture);
-      pd3dDevice->basicShader->SetTexture(SHADER_tex_base_color, m_textImg, SF_TRILINEAR, SA_REPEAT, SA_REPEAT, false);
+      pd3dDevice->basicShader->SetTexture(SHADER_tex_base_color, m_textImg, SF_TRILINEAR, SA_REPEAT, SA_REPEAT);
       pd3dDevice->basicShader->SetAlphaTestValue(-1.0f);
    }
    else
@@ -553,7 +553,7 @@ void Decal::RenderObject()
             pd3dDevice->basicShader->SetTechniqueMetal(SHADER_TECHNIQUE_basic_with_texture, mat->m_bIsMetal);
          else
             pd3dDevice->basicShader->SetTechnique(SHADER_TECHNIQUE_bg_decal_with_texture);
-         pd3dDevice->basicShader->SetTexture(SHADER_tex_base_color, pin, SF_TRILINEAR, SA_REPEAT, SA_REPEAT, false);
+         pd3dDevice->basicShader->SetTexture(SHADER_tex_base_color, pin, SF_TRILINEAR, SA_REPEAT, SA_REPEAT);
          pd3dDevice->basicShader->SetAlphaTestValue(pin->m_alphaTestValue * (float)(1.0 / 255.0));
       }
       else

--- a/decal.cpp
+++ b/decal.cpp
@@ -541,7 +541,7 @@ void Decal::RenderObject()
          pd3dDevice->basicShader->SetTechniqueMetal(SHADER_TECHNIQUE_basic_with_texture, mat->m_bIsMetal);
       else
          pd3dDevice->basicShader->SetTechnique(SHADER_TECHNIQUE_bg_decal_with_texture);
-      pd3dDevice->basicShader->SetTexture(SHADER_tex_base_color, m_textImg, SF_TRILINEAR, SA_REPEAT, SA_REPEAT);
+      pd3dDevice->basicShader->SetTexture(SHADER_tex_base_color, m_textImg);
       pd3dDevice->basicShader->SetAlphaTestValue(-1.0f);
    }
    else
@@ -553,7 +553,7 @@ void Decal::RenderObject()
             pd3dDevice->basicShader->SetTechniqueMetal(SHADER_TECHNIQUE_basic_with_texture, mat->m_bIsMetal);
          else
             pd3dDevice->basicShader->SetTechnique(SHADER_TECHNIQUE_bg_decal_with_texture);
-         pd3dDevice->basicShader->SetTexture(SHADER_tex_base_color, pin, SF_TRILINEAR, SA_REPEAT, SA_REPEAT);
+         pd3dDevice->basicShader->SetTexture(SHADER_tex_base_color, pin);
          pd3dDevice->basicShader->SetAlphaTestValue(pin->m_alphaTestValue * (float)(1.0 / 255.0));
       }
       else

--- a/dispreel.cpp
+++ b/dispreel.cpp
@@ -237,7 +237,7 @@ void DispReel::RenderDynamic()
    const vec4 c = convertColor(0xFFFFFFFF, 1.f);
    pd3dDevice->DMDShader->SetVector(SHADER_vColor_Intensity, &c);
 
-   pd3dDevice->DMDShader->SetTexture(SHADER_tex_sprite, pin, SF_TRILINEAR, SA_REPEAT, SA_REPEAT, false);
+   pd3dDevice->DMDShader->SetTexture(SHADER_tex_sprite, pin, SF_TRILINEAR, SA_REPEAT, SA_REPEAT);
 
    pd3dDevice->DMDShader->Begin();
 

--- a/dispreel.cpp
+++ b/dispreel.cpp
@@ -237,7 +237,7 @@ void DispReel::RenderDynamic()
    const vec4 c = convertColor(0xFFFFFFFF, 1.f);
    pd3dDevice->DMDShader->SetVector(SHADER_vColor_Intensity, &c);
 
-   pd3dDevice->DMDShader->SetTexture(SHADER_tex_sprite, pin, TextureFilter::TEXTURE_MODE_TRILINEAR, false, false, false);
+   pd3dDevice->DMDShader->SetTexture(SHADER_tex_sprite, pin, SF_TRILINEAR, SA_REPEAT, SA_REPEAT, false);
 
    pd3dDevice->DMDShader->Begin();
 

--- a/flasher.cpp
+++ b/flasher.cpp
@@ -1214,7 +1214,7 @@ void Flasher::RenderDynamic()
           pd3dDevice->DMDShader->SetTechnique(SHADER_TECHNIQUE_basic_DMD_world_ext);
 
        if (g_pplayer->m_texdmd != nullptr)
-          pd3dDevice->DMDShader->SetTexture(SHADER_tex_dmd, g_pplayer->m_pin3d.m_pd3dPrimaryDevice->m_texMan.LoadTexture(g_pplayer->m_texdmd, TextureFilter::TEXTURE_MODE_NONE, true, true, false));
+          pd3dDevice->DMDShader->SetTexture(SHADER_tex_dmd, g_pplayer->m_texdmd, SF_NONE, SA_CLAMP, SA_CLAMP, false);
 
        pd3dDevice->DMDShader->Begin();
        pd3dDevice->DrawIndexedPrimitiveVB(RenderDevice::TRIANGLELIST, MY_D3DFVF_TEX, m_dynamicVertexBuffer, 0, m_numVertices, m_dynamicIndexBuffer, 0, m_numPolys * 3);
@@ -1243,7 +1243,7 @@ void Flasher::RenderDynamic()
        if (pinA && !pinB)
        {
           flasherMode = 0.f;
-          pd3dDevice->flasherShader->SetTexture(SHADER_tex_flasher_A, pinA, TextureFilter::TEXTURE_MODE_TRILINEAR, true, true, false);
+          pd3dDevice->flasherShader->SetTexture(SHADER_tex_flasher_A, pinA, SF_TRILINEAR, SA_CLAMP, SA_CLAMP, false);
 
           if (!m_d.m_addBlend)
              flasherData.x = pinA->m_alphaTestValue * (float)(1.0/255.0);
@@ -1253,7 +1253,7 @@ void Flasher::RenderDynamic()
        else if (!pinA && pinB)
        {
           flasherMode = 0.f;
-          pd3dDevice->flasherShader->SetTexture(SHADER_tex_flasher_A, pinB, TextureFilter::TEXTURE_MODE_TRILINEAR, true, true, false);
+          pd3dDevice->flasherShader->SetTexture(SHADER_tex_flasher_A, pinB, SF_TRILINEAR, SA_CLAMP, SA_CLAMP, false);
 
           if (!m_d.m_addBlend)
              flasherData.x = pinB->m_alphaTestValue * (float)(1.0/255.0);
@@ -1263,8 +1263,8 @@ void Flasher::RenderDynamic()
        else if (pinA && pinB)
        {
           flasherMode = 1.f;
-          pd3dDevice->flasherShader->SetTexture(SHADER_tex_flasher_A, pinA, TextureFilter::TEXTURE_MODE_TRILINEAR, true, true, false);
-          pd3dDevice->flasherShader->SetTexture(SHADER_tex_flasher_B, pinB, TextureFilter::TEXTURE_MODE_TRILINEAR, true, true, false);
+          pd3dDevice->flasherShader->SetTexture(SHADER_tex_flasher_A, pinA, SF_TRILINEAR, SA_CLAMP, SA_CLAMP, false);
+          pd3dDevice->flasherShader->SetTexture(SHADER_tex_flasher_B, pinB, SF_TRILINEAR, SA_CLAMP, SA_CLAMP, false);
 
           if (!m_d.m_addBlend)
           {

--- a/flasher.cpp
+++ b/flasher.cpp
@@ -1214,7 +1214,7 @@ void Flasher::RenderDynamic()
           pd3dDevice->DMDShader->SetTechnique(SHADER_TECHNIQUE_basic_DMD_world_ext);
 
        if (g_pplayer->m_texdmd != nullptr)
-          pd3dDevice->DMDShader->SetTexture(SHADER_tex_dmd, g_pplayer->m_texdmd, SF_NONE, SA_CLAMP, SA_CLAMP, false);
+          pd3dDevice->DMDShader->SetTexture(SHADER_tex_dmd, g_pplayer->m_texdmd, SF_NONE, SA_CLAMP, SA_CLAMP);
 
        pd3dDevice->DMDShader->Begin();
        pd3dDevice->DrawIndexedPrimitiveVB(RenderDevice::TRIANGLELIST, MY_D3DFVF_TEX, m_dynamicVertexBuffer, 0, m_numVertices, m_dynamicIndexBuffer, 0, m_numPolys * 3);
@@ -1243,7 +1243,7 @@ void Flasher::RenderDynamic()
        if (pinA && !pinB)
        {
           flasherMode = 0.f;
-          pd3dDevice->flasherShader->SetTexture(SHADER_tex_flasher_A, pinA, SF_TRILINEAR, SA_CLAMP, SA_CLAMP, false);
+          pd3dDevice->flasherShader->SetTexture(SHADER_tex_flasher_A, pinA, SF_TRILINEAR, SA_CLAMP, SA_CLAMP);
 
           if (!m_d.m_addBlend)
              flasherData.x = pinA->m_alphaTestValue * (float)(1.0/255.0);
@@ -1253,7 +1253,7 @@ void Flasher::RenderDynamic()
        else if (!pinA && pinB)
        {
           flasherMode = 0.f;
-          pd3dDevice->flasherShader->SetTexture(SHADER_tex_flasher_A, pinB, SF_TRILINEAR, SA_CLAMP, SA_CLAMP, false);
+          pd3dDevice->flasherShader->SetTexture(SHADER_tex_flasher_A, pinB, SF_TRILINEAR, SA_CLAMP, SA_CLAMP);
 
           if (!m_d.m_addBlend)
              flasherData.x = pinB->m_alphaTestValue * (float)(1.0/255.0);
@@ -1263,8 +1263,8 @@ void Flasher::RenderDynamic()
        else if (pinA && pinB)
        {
           flasherMode = 1.f;
-          pd3dDevice->flasherShader->SetTexture(SHADER_tex_flasher_A, pinA, SF_TRILINEAR, SA_CLAMP, SA_CLAMP, false);
-          pd3dDevice->flasherShader->SetTexture(SHADER_tex_flasher_B, pinB, SF_TRILINEAR, SA_CLAMP, SA_CLAMP, false);
+          pd3dDevice->flasherShader->SetTexture(SHADER_tex_flasher_A, pinA, SF_TRILINEAR, SA_CLAMP, SA_CLAMP);
+          pd3dDevice->flasherShader->SetTexture(SHADER_tex_flasher_B, pinB, SF_TRILINEAR, SA_CLAMP, SA_CLAMP);
 
           if (!m_d.m_addBlend)
           {

--- a/flasher.cpp
+++ b/flasher.cpp
@@ -1243,7 +1243,7 @@ void Flasher::RenderDynamic()
        if (pinA && !pinB)
        {
           flasherMode = 0.f;
-          pd3dDevice->flasherShader->SetTexture(SHADER_tex_flasher_A, pinA, SF_TRILINEAR, SA_CLAMP, SA_CLAMP);
+          pd3dDevice->flasherShader->SetTexture(SHADER_tex_flasher_A, pinA);
 
           if (!m_d.m_addBlend)
              flasherData.x = pinA->m_alphaTestValue * (float)(1.0/255.0);
@@ -1253,7 +1253,7 @@ void Flasher::RenderDynamic()
        else if (!pinA && pinB)
        {
           flasherMode = 0.f;
-          pd3dDevice->flasherShader->SetTexture(SHADER_tex_flasher_A, pinB, SF_TRILINEAR, SA_CLAMP, SA_CLAMP);
+          pd3dDevice->flasherShader->SetTexture(SHADER_tex_flasher_A, pinB);
 
           if (!m_d.m_addBlend)
              flasherData.x = pinB->m_alphaTestValue * (float)(1.0/255.0);
@@ -1263,8 +1263,8 @@ void Flasher::RenderDynamic()
        else if (pinA && pinB)
        {
           flasherMode = 1.f;
-          pd3dDevice->flasherShader->SetTexture(SHADER_tex_flasher_A, pinA, SF_TRILINEAR, SA_CLAMP, SA_CLAMP);
-          pd3dDevice->flasherShader->SetTexture(SHADER_tex_flasher_B, pinB, SF_TRILINEAR, SA_CLAMP, SA_CLAMP);
+          pd3dDevice->flasherShader->SetTexture(SHADER_tex_flasher_A, pinA);
+          pd3dDevice->flasherShader->SetTexture(SHADER_tex_flasher_B, pinB);
 
           if (!m_d.m_addBlend)
           {

--- a/flipper.cpp
+++ b/flipper.cpp
@@ -610,7 +610,7 @@ void Flipper::RenderDynamic()
    if (pin)
    {
       pd3dDevice->basicShader->SetTechniqueMetal(SHADER_TECHNIQUE_basic_with_texture, mat->m_bIsMetal);
-      pd3dDevice->basicShader->SetTexture(SHADER_tex_base_color, pin, SF_TRILINEAR, SA_REPEAT, SA_REPEAT);
+      pd3dDevice->basicShader->SetTexture(SHADER_tex_base_color, pin);
       pd3dDevice->basicShader->SetAlphaTestValue(pin->m_alphaTestValue * (float)(1.0 / 255.0));
 
       //g_pplayer->m_pin3d.SetPrimaryTextureFilter(0, TEXTURE_MODE_TRILINEAR);

--- a/flipper.cpp
+++ b/flipper.cpp
@@ -610,7 +610,7 @@ void Flipper::RenderDynamic()
    if (pin)
    {
       pd3dDevice->basicShader->SetTechniqueMetal(SHADER_TECHNIQUE_basic_with_texture, mat->m_bIsMetal);
-      pd3dDevice->basicShader->SetTexture(SHADER_tex_base_color, pin, SF_TRILINEAR, SA_REPEAT, SA_REPEAT, false);
+      pd3dDevice->basicShader->SetTexture(SHADER_tex_base_color, pin, SF_TRILINEAR, SA_REPEAT, SA_REPEAT);
       pd3dDevice->basicShader->SetAlphaTestValue(pin->m_alphaTestValue * (float)(1.0 / 255.0));
 
       //g_pplayer->m_pin3d.SetPrimaryTextureFilter(0, TEXTURE_MODE_TRILINEAR);

--- a/flipper.cpp
+++ b/flipper.cpp
@@ -610,7 +610,7 @@ void Flipper::RenderDynamic()
    if (pin)
    {
       pd3dDevice->basicShader->SetTechniqueMetal(SHADER_TECHNIQUE_basic_with_texture, mat->m_bIsMetal);
-      pd3dDevice->basicShader->SetTexture(SHADER_tex_base_color, pin, TextureFilter::TEXTURE_MODE_TRILINEAR, false, false, false);
+      pd3dDevice->basicShader->SetTexture(SHADER_tex_base_color, pin, SF_TRILINEAR, SA_REPEAT, SA_REPEAT, false);
       pd3dDevice->basicShader->SetAlphaTestValue(pin->m_alphaTestValue * (float)(1.0 / 255.0));
 
       //g_pplayer->m_pin3d.SetPrimaryTextureFilter(0, TEXTURE_MODE_TRILINEAR);

--- a/hittarget.cpp
+++ b/hittarget.cpp
@@ -707,7 +707,7 @@ void HitTarget::RenderObject()
    if (pin)
    {
       pd3dDevice->basicShader->SetTechniqueMetal(SHADER_TECHNIQUE_basic_with_texture, mat->m_bIsMetal);
-      pd3dDevice->basicShader->SetTexture(SHADER_tex_base_color, pin, SF_TRILINEAR, SA_REPEAT, SA_REPEAT, false);
+      pd3dDevice->basicShader->SetTexture(SHADER_tex_base_color, pin, SF_TRILINEAR, SA_REPEAT, SA_REPEAT);
       pd3dDevice->basicShader->SetAlphaTestValue(pin->m_alphaTestValue * (float)(1.0 / 255.0));
 
       //g_pplayer->m_pin3d.SetPrimaryTextureFilter(0, TEXTURE_MODE_TRILINEAR);

--- a/hittarget.cpp
+++ b/hittarget.cpp
@@ -707,7 +707,7 @@ void HitTarget::RenderObject()
    if (pin)
    {
       pd3dDevice->basicShader->SetTechniqueMetal(SHADER_TECHNIQUE_basic_with_texture, mat->m_bIsMetal);
-      pd3dDevice->basicShader->SetTexture(SHADER_tex_base_color, pin, SF_TRILINEAR, SA_REPEAT, SA_REPEAT);
+      pd3dDevice->basicShader->SetTexture(SHADER_tex_base_color, pin);
       pd3dDevice->basicShader->SetAlphaTestValue(pin->m_alphaTestValue * (float)(1.0 / 255.0));
 
       //g_pplayer->m_pin3d.SetPrimaryTextureFilter(0, TEXTURE_MODE_TRILINEAR);

--- a/hittarget.cpp
+++ b/hittarget.cpp
@@ -707,7 +707,7 @@ void HitTarget::RenderObject()
    if (pin)
    {
       pd3dDevice->basicShader->SetTechniqueMetal(SHADER_TECHNIQUE_basic_with_texture, mat->m_bIsMetal);
-      pd3dDevice->basicShader->SetTexture(SHADER_tex_base_color, pin, TextureFilter::TEXTURE_MODE_TRILINEAR, false, false, false);
+      pd3dDevice->basicShader->SetTexture(SHADER_tex_base_color, pin, SF_TRILINEAR, SA_REPEAT, SA_REPEAT, false);
       pd3dDevice->basicShader->SetAlphaTestValue(pin->m_alphaTestValue * (float)(1.0 / 255.0));
 
       //g_pplayer->m_pin3d.SetPrimaryTextureFilter(0, TEXTURE_MODE_TRILINEAR);

--- a/kicker.cpp
+++ b/kicker.cpp
@@ -558,7 +558,7 @@ void Kicker::RenderDynamic()
       if (m_d.m_kickertype != KickerHoleSimple)
       {
          pd3dDevice->basicShader->SetTechniqueMetal(SHADER_TECHNIQUE_basic_with_texture, mat->m_bIsMetal);
-         pd3dDevice->basicShader->SetTexture(SHADER_tex_base_color, &m_texture, SF_TRILINEAR, SA_REPEAT, SA_REPEAT, false);
+         pd3dDevice->basicShader->SetTexture(SHADER_tex_base_color, &m_texture, SF_TRILINEAR, SA_REPEAT, SA_REPEAT);
       }
       else
          pd3dDevice->basicShader->SetTechniqueMetal(SHADER_TECHNIQUE_basic_without_texture, mat->m_bIsMetal);

--- a/kicker.cpp
+++ b/kicker.cpp
@@ -558,7 +558,7 @@ void Kicker::RenderDynamic()
       if (m_d.m_kickertype != KickerHoleSimple)
       {
          pd3dDevice->basicShader->SetTechniqueMetal(SHADER_TECHNIQUE_basic_with_texture, mat->m_bIsMetal);
-         pd3dDevice->basicShader->SetTexture(SHADER_tex_base_color, &m_texture, SF_TRILINEAR, SA_REPEAT, SA_REPEAT);
+         pd3dDevice->basicShader->SetTexture(SHADER_tex_base_color, &m_texture);
       }
       else
          pd3dDevice->basicShader->SetTechniqueMetal(SHADER_TECHNIQUE_basic_without_texture, mat->m_bIsMetal);

--- a/kicker.cpp
+++ b/kicker.cpp
@@ -558,7 +558,7 @@ void Kicker::RenderDynamic()
       if (m_d.m_kickertype != KickerHoleSimple)
       {
          pd3dDevice->basicShader->SetTechniqueMetal(SHADER_TECHNIQUE_basic_with_texture, mat->m_bIsMetal);
-         pd3dDevice->basicShader->SetTexture(SHADER_tex_base_color, &m_texture, TextureFilter::TEXTURE_MODE_TRILINEAR, false, false, false);
+         pd3dDevice->basicShader->SetTexture(SHADER_tex_base_color, &m_texture, SF_TRILINEAR, SA_REPEAT, SA_REPEAT, false);
       }
       else
          pd3dDevice->basicShader->SetTechniqueMetal(SHADER_TECHNIQUE_basic_without_texture, mat->m_bIsMetal);

--- a/light.cpp
+++ b/light.cpp
@@ -482,7 +482,7 @@ void Light::RenderDynamic()
       if (offTexel != nullptr)
       {
          pd3dDevice->classicLightShader->SetTechniqueMetal(SHADER_TECHNIQUE_light_with_texture, m_surfaceMaterial->m_bIsMetal);
-         pd3dDevice->classicLightShader->SetTexture(SHADER_tex_light_color, offTexel, SF_TRILINEAR, SA_CLAMP, SA_CLAMP, false);
+         pd3dDevice->classicLightShader->SetTexture(SHADER_tex_light_color, offTexel, SF_TRILINEAR, SA_CLAMP, SA_CLAMP);
          // Was: if (m_ptable->m_reflectElementsOnPlayfield && g_pplayer->m_pf_refl && !m_backglass)*/
          // TOTAN and Flintstones inserts break if alpha blending is disabled here.
          // Also see below if changing again

--- a/light.cpp
+++ b/light.cpp
@@ -482,7 +482,7 @@ void Light::RenderDynamic()
       if (offTexel != nullptr)
       {
          pd3dDevice->classicLightShader->SetTechniqueMetal(SHADER_TECHNIQUE_light_with_texture, m_surfaceMaterial->m_bIsMetal);
-         pd3dDevice->classicLightShader->SetTexture(SHADER_tex_light_color, offTexel, TextureFilter::TEXTURE_MODE_TRILINEAR, true, true, false);
+         pd3dDevice->classicLightShader->SetTexture(SHADER_tex_light_color, offTexel, SF_TRILINEAR, SA_CLAMP, SA_CLAMP, false);
          // Was: if (m_ptable->m_reflectElementsOnPlayfield && g_pplayer->m_pf_refl && !m_backglass)*/
          // TOTAN and Flintstones inserts break if alpha blending is disabled here.
          // Also see below if changing again

--- a/pin/player.cpp
+++ b/pin/player.cpp
@@ -1138,8 +1138,8 @@ void Player::InitShader()
    //m_pin3d.m_pd3dPrimaryDevice->classicLightShader->SetVector("camera", &cam);
 #endif
 
-   m_pin3d.m_pd3dPrimaryDevice->basicShader->SetTexture(SHADER_tex_env, m_pin3d.m_envTexture ? m_pin3d.m_envTexture : &m_pin3d.m_builtinEnvTexture, SF_TRILINEAR, SA_REPEAT, SA_CLAMP);
-   m_pin3d.m_pd3dPrimaryDevice->basicShader->SetTexture(SHADER_tex_diffuse_env, m_pin3d.m_envRadianceTexture, SF_BILINEAR, SA_REPEAT, SA_CLAMP);
+   m_pin3d.m_pd3dPrimaryDevice->basicShader->SetTexture(SHADER_tex_env, m_pin3d.m_envTexture ? m_pin3d.m_envTexture : &m_pin3d.m_builtinEnvTexture);
+   m_pin3d.m_pd3dPrimaryDevice->basicShader->SetTexture(SHADER_tex_diffuse_env, m_pin3d.m_envRadianceTexture);
 #ifdef SEPARATE_CLASSICLIGHTSHADER
    m_pin3d.m_pd3dPrimaryDevice->classicLightShader->SetTexture(SHADER_tex_env, m_pin3d.m_envTexture ? m_pin3d.m_envTexture : &m_pin3d.m_builtinEnvTexture, TextureFilter::TEXTURE_MODE_TRILINEAR, false, true, false);
    m_pin3d.m_pd3dPrimaryDevice->classicLightShader->SetTexture(SHADER_tex_diffuse_env, m_envRadianceTexture, TextureFilter::TEXTURE_MODE_BILINEAR, false, true, false);
@@ -1231,9 +1231,9 @@ void Player::InitBallShader()
 
    Texture * const playfield = m_ptable->GetImage(m_ptable->m_image);
    if (playfield)
-      m_ballShader->SetTexture(SHADER_tex_ball_playfield, playfield, SF_TRILINEAR, SA_REPEAT, SA_REPEAT);
+      m_ballShader->SetTexture(SHADER_tex_ball_playfield, playfield);
 
-   m_ballShader->SetTexture(SHADER_tex_diffuse_env, m_pin3d.m_envRadianceTexture, SF_BILINEAR, SA_REPEAT, SA_CLAMP);
+   m_ballShader->SetTexture(SHADER_tex_diffuse_env, m_pin3d.m_envRadianceTexture);
 
    assert(m_ballIndexBuffer == nullptr);
    const bool lowDetailBall = (m_ptable->GetDetailLevel() < 10);
@@ -2295,7 +2295,7 @@ void Player::InitStatic()
       m_pin3d.m_pd3dPrimaryDevice->Clear(clearType::TARGET, 0, 1.0f, 0L);
 
       m_pin3d.m_pd3dPrimaryDevice->FBShader->SetTexture(SHADER_tex_depth, tmpDepth->GetDepthSampler());
-      m_pin3d.m_pd3dPrimaryDevice->FBShader->SetTexture(SHADER_tex_ao_dither, &m_pin3d.m_aoDitherTexture, SF_NONE, SA_REPEAT, SA_REPEAT, true);
+      m_pin3d.m_pd3dPrimaryDevice->FBShader->SetTexture(SHADER_tex_ao_dither, &m_pin3d.m_aoDitherTexture, SF_UNDEFINED, SA_UNDEFINED, SA_UNDEFINED, true); // FIXME the force linear RGB is not honored
       const vec4 ao_s_tb(m_ptable->m_AOScale, 0.1f, 0.f,0.f);
       m_pin3d.m_pd3dPrimaryDevice->FBShader->SetVector(SHADER_AO_scale_timeblur, &ao_s_tb);
       m_pin3d.m_pd3dPrimaryDevice->FBShader->SetTechnique(SHADER_TECHNIQUE_AO);
@@ -3879,7 +3879,7 @@ void Player::SSRefl()
    m_pin3d.m_pd3dPrimaryDevice->FBShader->SetTexture(SHADER_tex_fb_filtered, m_pin3d.m_pd3dPrimaryDevice->GetBackBufferTexture()->GetColorSampler());
    m_pin3d.m_pd3dPrimaryDevice->FBShader->SetTexture(SHADER_tex_fb_unfiltered, m_pin3d.m_pd3dPrimaryDevice->GetBackBufferTexture()->GetColorSampler());
    m_pin3d.m_pd3dPrimaryDevice->FBShader->SetTexture(SHADER_tex_depth, m_pin3d.m_pd3dPrimaryDevice->GetBackBufferTexture()->GetDepthSampler());
-   m_pin3d.m_pd3dPrimaryDevice->FBShader->SetTexture(SHADER_tex_ao_dither, &m_pin3d.m_aoDitherTexture, SF_NONE, SA_REPEAT, SA_REPEAT, true); //!!!
+   m_pin3d.m_pd3dPrimaryDevice->FBShader->SetTexture(SHADER_tex_ao_dither, &m_pin3d.m_aoDitherTexture, SF_UNDEFINED, SA_UNDEFINED, SA_UNDEFINED, true); // FIXME the force linear RGB is not honored
 
    // FIXME check if size should not be taken from renderdevice to account for VR (double width) or supersampling
    const vec4 w_h_height((float)(1.0 / (double)m_width), (float)(1.0 / (double)m_height), 1.0f/*radical_inverse(m_overall_frames%2048)*/, 1.0f);
@@ -4844,7 +4844,7 @@ void Player::PrepareVideoBuffersNormal()
    // Texture used for LUT color grading must be treated as if they were linear
    Texture *const pin = m_ptable->GetImage(m_ptable->m_imageColorGrade);
    if (pin)
-      m_pin3d.m_pd3dPrimaryDevice->FBShader->SetTexture(SHADER_tex_color_lut, pin, SF_BILINEAR, SA_CLAMP, SA_CLAMP, true);
+      m_pin3d.m_pd3dPrimaryDevice->FBShader->SetTexture(SHADER_tex_color_lut, pin, SF_UNDEFINED, SA_UNDEFINED, SA_UNDEFINED, true); // FIXME honor the linear RGB
    m_pin3d.m_pd3dPrimaryDevice->FBShader->SetBool(SHADER_color_grade, pin != nullptr);
    m_pin3d.m_pd3dPrimaryDevice->FBShader->SetBool(SHADER_do_dither, !m_ditherOff);
    m_pin3d.m_pd3dPrimaryDevice->FBShader->SetBool(SHADER_do_bloom, (m_ptable->m_bloom_strength > 0.0f && !m_bloomOff));
@@ -4955,7 +4955,7 @@ void Player::PrepareVideoBuffersAO()
 
    m_pin3d.m_pd3dPrimaryDevice->FBShader->SetTexture(SHADER_tex_fb_filtered, m_pin3d.m_pddsAOBackBuffer->GetColorSampler());
    //m_pin3d.m_pd3dDevice->FBShader->SetTexture(SHADER_Texture1, m_pin3d.m_pd3dDevice->GetBackBufferTmpTexture()); // temporary normals
-   m_pin3d.m_pd3dPrimaryDevice->FBShader->SetTexture(SHADER_tex_ao_dither, &m_pin3d.m_aoDitherTexture, SF_NONE, SA_REPEAT, SA_REPEAT, true);
+   m_pin3d.m_pd3dPrimaryDevice->FBShader->SetTexture(SHADER_tex_ao_dither, &m_pin3d.m_aoDitherTexture, SF_UNDEFINED, SA_UNDEFINED, SA_UNDEFINED, true); // FIXME the force linear RGB is not honored
    m_pin3d.m_pd3dPrimaryDevice->FBShader->SetTexture(SHADER_tex_depth, m_pin3d.m_pd3dPrimaryDevice->GetBackBufferTexture()->GetDepthSampler());
 
    const vec4 w_h_height((float)(1.0 / (double)m_width), (float)(1.0 / (double)m_height),
@@ -5010,7 +5010,7 @@ void Player::PrepareVideoBuffersAO()
    // Texture used for LUT color grading must be treated as if they were linear
    Texture *const pin = m_ptable->GetImage(m_ptable->m_imageColorGrade);
    if (pin)
-      m_pin3d.m_pd3dPrimaryDevice->FBShader->SetTexture(SHADER_tex_color_lut, pin, SF_BILINEAR, SA_CLAMP, SA_CLAMP, true);
+      m_pin3d.m_pd3dPrimaryDevice->FBShader->SetTexture(SHADER_tex_color_lut, pin, SF_UNDEFINED, SA_UNDEFINED, SA_UNDEFINED, true); // FIXME honor the linear RGB
    m_pin3d.m_pd3dPrimaryDevice->FBShader->SetBool(SHADER_color_grade, pin != nullptr);
    m_pin3d.m_pd3dPrimaryDevice->FBShader->SetBool(SHADER_do_dither, !m_ditherOff);
    m_pin3d.m_pd3dPrimaryDevice->FBShader->SetBool(SHADER_do_bloom, (m_ptable->m_bloom_strength > 0.0f && !m_bloomOff));
@@ -5901,12 +5901,12 @@ void Player::DrawBalls()
       m_ballShader->SetBool(SHADER_disableLighting, m_disableLightingForBalls);
 
       if (!pball->m_pinballEnv)
-         m_ballShader->SetTexture(SHADER_tex_ball_color, &m_pin3d.m_pinballEnvTexture, SF_TRILINEAR, SA_REPEAT, SA_REPEAT);
+         m_ballShader->SetTexture(SHADER_tex_ball_color, &m_pin3d.m_pinballEnvTexture);
       else
-         m_ballShader->SetTexture(SHADER_tex_ball_color, pball->m_pinballEnv, SF_TRILINEAR, SA_REPEAT, SA_REPEAT);
+         m_ballShader->SetTexture(SHADER_tex_ball_color, pball->m_pinballEnv);
 
       if (pball->m_pinballDecal)
-         m_ballShader->SetTexture(SHADER_tex_ball_decal, pball->m_pinballDecal, SF_TRILINEAR, SA_REPEAT, SA_REPEAT);
+         m_ballShader->SetTexture(SHADER_tex_ball_decal, pball->m_pinballDecal);
       else
          m_ballShader->SetTextureNull(SHADER_tex_ball_decal);
 

--- a/pin/player.cpp
+++ b/pin/player.cpp
@@ -1138,8 +1138,8 @@ void Player::InitShader()
    //m_pin3d.m_pd3dPrimaryDevice->classicLightShader->SetVector("camera", &cam);
 #endif
 
-   m_pin3d.m_pd3dPrimaryDevice->basicShader->SetTexture(SHADER_tex_env, m_pin3d.m_envTexture ? m_pin3d.m_envTexture : &m_pin3d.m_builtinEnvTexture, TextureFilter::TEXTURE_MODE_TRILINEAR, false, true, false);
-   m_pin3d.m_pd3dPrimaryDevice->basicShader->SetTexture(SHADER_tex_diffuse_env, m_pin3d.m_pd3dPrimaryDevice->m_texMan.LoadTexture(m_pin3d.m_envRadianceTexture, TextureFilter::TEXTURE_MODE_BILINEAR, false, true, false));
+   m_pin3d.m_pd3dPrimaryDevice->basicShader->SetTexture(SHADER_tex_env, m_pin3d.m_envTexture ? m_pin3d.m_envTexture : &m_pin3d.m_builtinEnvTexture, SF_TRILINEAR, SA_REPEAT, SA_CLAMP, false);
+   m_pin3d.m_pd3dPrimaryDevice->basicShader->SetTexture(SHADER_tex_diffuse_env, m_pin3d.m_pd3dPrimaryDevice->m_texMan.LoadTexture(m_pin3d.m_envRadianceTexture, SF_BILINEAR, SA_REPEAT, SA_CLAMP, false));
 #ifdef SEPARATE_CLASSICLIGHTSHADER
    m_pin3d.m_pd3dPrimaryDevice->classicLightShader->SetTexture(SHADER_tex_env, m_pin3d.m_envTexture ? m_pin3d.m_envTexture : &m_pin3d.m_builtinEnvTexture, TextureFilter::TEXTURE_MODE_TRILINEAR, false, true, false);
    m_pin3d.m_pd3dPrimaryDevice->classicLightShader->SetTexture(SHADER_tex_diffuse_env, m_pd3dPrimaryDevice->m_texMan.LoadTexture(m_envRadianceTexture, TextureFilter::TEXTURE_MODE_BILINEAR, false, true, false));
@@ -1231,9 +1231,9 @@ void Player::InitBallShader()
 
    Texture * const playfield = m_ptable->GetImage(m_ptable->m_image);
    if (playfield)
-      m_ballShader->SetTexture(SHADER_tex_ball_playfield, playfield, TextureFilter::TEXTURE_MODE_TRILINEAR, false, false, false);
+      m_ballShader->SetTexture(SHADER_tex_ball_playfield, playfield, SF_TRILINEAR, SA_REPEAT, SA_REPEAT, false);
 
-   m_ballShader->SetTexture(SHADER_tex_diffuse_env, m_pin3d.m_pd3dPrimaryDevice->m_texMan.LoadTexture(m_pin3d.m_envRadianceTexture, TextureFilter::TEXTURE_MODE_BILINEAR, false, true, false));
+   m_ballShader->SetTexture(SHADER_tex_diffuse_env, m_pin3d.m_pd3dPrimaryDevice->m_texMan.LoadTexture(m_pin3d.m_envRadianceTexture, SF_BILINEAR, SA_REPEAT, SA_CLAMP, false));
 
    assert(m_ballIndexBuffer == nullptr);
    const bool lowDetailBall = (m_ptable->GetDetailLevel() < 10);
@@ -2295,7 +2295,7 @@ void Player::InitStatic()
       m_pin3d.m_pd3dPrimaryDevice->Clear(clearType::TARGET, 0, 1.0f, 0L);
 
       m_pin3d.m_pd3dPrimaryDevice->FBShader->SetTexture(SHADER_tex_depth, tmpDepth->GetDepthSampler());
-      m_pin3d.m_pd3dPrimaryDevice->FBShader->SetTexture(SHADER_tex_ao_dither, &m_pin3d.m_aoDitherTexture, TextureFilter::TEXTURE_MODE_NONE, false, false, true);
+      m_pin3d.m_pd3dPrimaryDevice->FBShader->SetTexture(SHADER_tex_ao_dither, &m_pin3d.m_aoDitherTexture, SF_NONE, SA_REPEAT, SA_REPEAT, true);
       const vec4 ao_s_tb(m_ptable->m_AOScale, 0.1f, 0.f,0.f);
       m_pin3d.m_pd3dPrimaryDevice->FBShader->SetVector(SHADER_AO_scale_timeblur, &ao_s_tb);
       m_pin3d.m_pd3dPrimaryDevice->FBShader->SetTechnique(SHADER_TECHNIQUE_AO);
@@ -3511,7 +3511,7 @@ void Player::Spritedraw(const float posx, const float posy, const float width, c
    pd3dDevice->DMDShader->SetVector(SHADER_vColor_Intensity, &c);
 
    if (tex)
-      pd3dDevice->DMDShader->SetTexture(SHADER_tex_sprite, tex, TextureFilter::TEXTURE_MODE_NONE, false, false, false);
+      pd3dDevice->DMDShader->SetTexture(SHADER_tex_sprite, tex, SF_NONE, SA_REPEAT, SA_REPEAT, false);
 
    pd3dDevice->DMDShader->Begin();
    pd3dDevice->DrawTexturedQuad((Vertex3D_TexelOnly*)Verts);
@@ -3879,7 +3879,7 @@ void Player::SSRefl()
    m_pin3d.m_pd3dPrimaryDevice->FBShader->SetTexture(SHADER_tex_fb_filtered, m_pin3d.m_pd3dPrimaryDevice->GetBackBufferTexture()->GetColorSampler());
    m_pin3d.m_pd3dPrimaryDevice->FBShader->SetTexture(SHADER_tex_fb_unfiltered, m_pin3d.m_pd3dPrimaryDevice->GetBackBufferTexture()->GetColorSampler());
    m_pin3d.m_pd3dPrimaryDevice->FBShader->SetTexture(SHADER_tex_depth, m_pin3d.m_pd3dPrimaryDevice->GetBackBufferTexture()->GetDepthSampler());
-   m_pin3d.m_pd3dPrimaryDevice->FBShader->SetTexture(SHADER_tex_ao_dither, &m_pin3d.m_aoDitherTexture, TextureFilter::TEXTURE_MODE_NONE, false, false, true); //!!!
+   m_pin3d.m_pd3dPrimaryDevice->FBShader->SetTexture(SHADER_tex_ao_dither, &m_pin3d.m_aoDitherTexture, SF_NONE, SA_REPEAT, SA_REPEAT, true); //!!!
 
    // FIXME check if size should not be taken from renderdevice to account for VR (double width) or supersampling
    const vec4 w_h_height((float)(1.0 / (double)m_width), (float)(1.0 / (double)m_height), 1.0f/*radical_inverse(m_overall_frames%2048)*/, 1.0f);
@@ -4844,7 +4844,7 @@ void Player::PrepareVideoBuffersNormal()
    // Texture used for LUT color grading must be treated as if they were linear
    Texture *const pin = m_ptable->GetImage(m_ptable->m_imageColorGrade);
    if (pin)
-      m_pin3d.m_pd3dPrimaryDevice->FBShader->SetTexture(SHADER_tex_color_lut, pin, TextureFilter::TEXTURE_MODE_BILINEAR, true, true, true);
+      m_pin3d.m_pd3dPrimaryDevice->FBShader->SetTexture(SHADER_tex_color_lut, pin, SF_BILINEAR, SA_CLAMP, SA_CLAMP, true);
    m_pin3d.m_pd3dPrimaryDevice->FBShader->SetBool(SHADER_color_grade, pin != nullptr);
    m_pin3d.m_pd3dPrimaryDevice->FBShader->SetBool(SHADER_do_dither, !m_ditherOff);
    m_pin3d.m_pd3dPrimaryDevice->FBShader->SetBool(SHADER_do_bloom, (m_ptable->m_bloom_strength > 0.0f && !m_bloomOff));
@@ -4955,7 +4955,7 @@ void Player::PrepareVideoBuffersAO()
 
    m_pin3d.m_pd3dPrimaryDevice->FBShader->SetTexture(SHADER_tex_fb_filtered, m_pin3d.m_pddsAOBackBuffer->GetColorSampler());
    //m_pin3d.m_pd3dDevice->FBShader->SetTexture(SHADER_Texture1, m_pin3d.m_pd3dDevice->GetBackBufferTmpTexture()); // temporary normals
-   m_pin3d.m_pd3dPrimaryDevice->FBShader->SetTexture(SHADER_tex_ao_dither, &m_pin3d.m_aoDitherTexture, TextureFilter::TEXTURE_MODE_NONE, false, false, true);
+   m_pin3d.m_pd3dPrimaryDevice->FBShader->SetTexture(SHADER_tex_ao_dither, &m_pin3d.m_aoDitherTexture, SF_NONE, SA_REPEAT, SA_REPEAT, true);
    m_pin3d.m_pd3dPrimaryDevice->FBShader->SetTexture(SHADER_tex_depth, m_pin3d.m_pd3dPrimaryDevice->GetBackBufferTexture()->GetDepthSampler());
 
    const vec4 w_h_height((float)(1.0 / (double)m_width), (float)(1.0 / (double)m_height),
@@ -5010,7 +5010,7 @@ void Player::PrepareVideoBuffersAO()
    // Texture used for LUT color grading must be treated as if they were linear
    Texture *const pin = m_ptable->GetImage(m_ptable->m_imageColorGrade);
    if (pin)
-      m_pin3d.m_pd3dPrimaryDevice->FBShader->SetTexture(SHADER_tex_color_lut, pin, TextureFilter::TEXTURE_MODE_BILINEAR, true, true, true);
+      m_pin3d.m_pd3dPrimaryDevice->FBShader->SetTexture(SHADER_tex_color_lut, pin, SF_BILINEAR, SA_CLAMP, SA_CLAMP, true);
    m_pin3d.m_pd3dPrimaryDevice->FBShader->SetBool(SHADER_color_grade, pin != nullptr);
    m_pin3d.m_pd3dPrimaryDevice->FBShader->SetBool(SHADER_do_dither, !m_ditherOff);
    m_pin3d.m_pd3dPrimaryDevice->FBShader->SetBool(SHADER_do_bloom, (m_ptable->m_bloom_strength > 0.0f && !m_bloomOff));
@@ -5901,12 +5901,12 @@ void Player::DrawBalls()
       m_ballShader->SetBool(SHADER_disableLighting, m_disableLightingForBalls);
 
       if (!pball->m_pinballEnv)
-         m_ballShader->SetTexture(SHADER_tex_ball_color, &m_pin3d.m_pinballEnvTexture, TextureFilter::TEXTURE_MODE_TRILINEAR, false, false, false);
+         m_ballShader->SetTexture(SHADER_tex_ball_color, &m_pin3d.m_pinballEnvTexture, SF_TRILINEAR, SA_REPEAT, SA_REPEAT, false);
       else
-         m_ballShader->SetTexture(SHADER_tex_ball_color, pball->m_pinballEnv, TextureFilter::TEXTURE_MODE_TRILINEAR, false, false, false);
+         m_ballShader->SetTexture(SHADER_tex_ball_color, pball->m_pinballEnv, SF_TRILINEAR, SA_REPEAT, SA_REPEAT, false);
 
       if (pball->m_pinballDecal)
-         m_ballShader->SetTexture(SHADER_tex_ball_decal, pball->m_pinballDecal, TextureFilter::TEXTURE_MODE_TRILINEAR, false, false, false);
+         m_ballShader->SetTexture(SHADER_tex_ball_decal, pball->m_pinballDecal, SF_TRILINEAR, SA_REPEAT, SA_REPEAT, false);
       else
          m_ballShader->SetTextureNull(SHADER_tex_ball_decal);
 

--- a/pin/player.cpp
+++ b/pin/player.cpp
@@ -1138,11 +1138,11 @@ void Player::InitShader()
    //m_pin3d.m_pd3dPrimaryDevice->classicLightShader->SetVector("camera", &cam);
 #endif
 
-   m_pin3d.m_pd3dPrimaryDevice->basicShader->SetTexture(SHADER_tex_env, m_pin3d.m_envTexture ? m_pin3d.m_envTexture : &m_pin3d.m_builtinEnvTexture, SF_TRILINEAR, SA_REPEAT, SA_CLAMP, false);
-   m_pin3d.m_pd3dPrimaryDevice->basicShader->SetTexture(SHADER_tex_diffuse_env, m_pin3d.m_pd3dPrimaryDevice->m_texMan.LoadTexture(m_pin3d.m_envRadianceTexture, SF_BILINEAR, SA_REPEAT, SA_CLAMP, false));
+   m_pin3d.m_pd3dPrimaryDevice->basicShader->SetTexture(SHADER_tex_env, m_pin3d.m_envTexture ? m_pin3d.m_envTexture : &m_pin3d.m_builtinEnvTexture, SF_TRILINEAR, SA_REPEAT, SA_CLAMP);
+   m_pin3d.m_pd3dPrimaryDevice->basicShader->SetTexture(SHADER_tex_diffuse_env, m_pin3d.m_envRadianceTexture, SF_BILINEAR, SA_REPEAT, SA_CLAMP);
 #ifdef SEPARATE_CLASSICLIGHTSHADER
    m_pin3d.m_pd3dPrimaryDevice->classicLightShader->SetTexture(SHADER_tex_env, m_pin3d.m_envTexture ? m_pin3d.m_envTexture : &m_pin3d.m_builtinEnvTexture, TextureFilter::TEXTURE_MODE_TRILINEAR, false, true, false);
-   m_pin3d.m_pd3dPrimaryDevice->classicLightShader->SetTexture(SHADER_tex_diffuse_env, m_pd3dPrimaryDevice->m_texMan.LoadTexture(m_envRadianceTexture, TextureFilter::TEXTURE_MODE_BILINEAR, false, true, false));
+   m_pin3d.m_pd3dPrimaryDevice->classicLightShader->SetTexture(SHADER_tex_diffuse_env, m_envRadianceTexture, TextureFilter::TEXTURE_MODE_BILINEAR, false, true, false);
 #endif
    const vec4 st(m_ptable->m_envEmissionScale*m_globalEmissionScale, m_pin3d.m_envTexture ? (float)m_pin3d.m_envTexture->m_height/*+m_pin3d.m_envTexture->m_width)*0.5f*/ : (float)m_pin3d.m_builtinEnvTexture.m_height/*+m_pin3d.m_builtinEnvTexture.m_width)*0.5f*/, 0.f, 0.f);
    m_pin3d.m_pd3dPrimaryDevice->basicShader->SetVector(SHADER_fenvEmissionScale_TexWidth, &st);
@@ -1231,9 +1231,9 @@ void Player::InitBallShader()
 
    Texture * const playfield = m_ptable->GetImage(m_ptable->m_image);
    if (playfield)
-      m_ballShader->SetTexture(SHADER_tex_ball_playfield, playfield, SF_TRILINEAR, SA_REPEAT, SA_REPEAT, false);
+      m_ballShader->SetTexture(SHADER_tex_ball_playfield, playfield, SF_TRILINEAR, SA_REPEAT, SA_REPEAT);
 
-   m_ballShader->SetTexture(SHADER_tex_diffuse_env, m_pin3d.m_pd3dPrimaryDevice->m_texMan.LoadTexture(m_pin3d.m_envRadianceTexture, SF_BILINEAR, SA_REPEAT, SA_CLAMP, false));
+   m_ballShader->SetTexture(SHADER_tex_diffuse_env, m_pin3d.m_envRadianceTexture, SF_BILINEAR, SA_REPEAT, SA_CLAMP);
 
    assert(m_ballIndexBuffer == nullptr);
    const bool lowDetailBall = (m_ptable->GetDetailLevel() < 10);
@@ -3478,7 +3478,7 @@ void Player::DMDdraw(const float DMDposx, const float DMDposy, const float DMDwi
 #endif
       m_pin3d.m_pd3dPrimaryDevice->DMDShader->SetVector(SHADER_vRes_Alpha_time, &r);
 
-      m_pin3d.m_pd3dPrimaryDevice->DMDShader->SetTexture(SHADER_tex_dmd, m_pin3d.m_pd3dPrimaryDevice->m_texMan.LoadTexture(m_texdmd), false, false);
+      m_pin3d.m_pd3dPrimaryDevice->DMDShader->SetTexture(SHADER_tex_dmd, m_texdmd, false, false);
 
       m_pin3d.m_pd3dPrimaryDevice->DMDShader->Begin();
       m_pin3d.m_pd3dPrimaryDevice->DrawTexturedQuad((Vertex3D_TexelOnly*)DMDVerts);
@@ -3511,7 +3511,7 @@ void Player::Spritedraw(const float posx, const float posy, const float width, c
    pd3dDevice->DMDShader->SetVector(SHADER_vColor_Intensity, &c);
 
    if (tex)
-      pd3dDevice->DMDShader->SetTexture(SHADER_tex_sprite, tex, SF_NONE, SA_REPEAT, SA_REPEAT, false);
+      pd3dDevice->DMDShader->SetTexture(SHADER_tex_sprite, tex, SF_NONE, SA_REPEAT, SA_REPEAT);
 
    pd3dDevice->DMDShader->Begin();
    pd3dDevice->DrawTexturedQuad((Vertex3D_TexelOnly*)Verts);
@@ -5901,12 +5901,12 @@ void Player::DrawBalls()
       m_ballShader->SetBool(SHADER_disableLighting, m_disableLightingForBalls);
 
       if (!pball->m_pinballEnv)
-         m_ballShader->SetTexture(SHADER_tex_ball_color, &m_pin3d.m_pinballEnvTexture, SF_TRILINEAR, SA_REPEAT, SA_REPEAT, false);
+         m_ballShader->SetTexture(SHADER_tex_ball_color, &m_pin3d.m_pinballEnvTexture, SF_TRILINEAR, SA_REPEAT, SA_REPEAT);
       else
-         m_ballShader->SetTexture(SHADER_tex_ball_color, pball->m_pinballEnv, SF_TRILINEAR, SA_REPEAT, SA_REPEAT, false);
+         m_ballShader->SetTexture(SHADER_tex_ball_color, pball->m_pinballEnv, SF_TRILINEAR, SA_REPEAT, SA_REPEAT);
 
       if (pball->m_pinballDecal)
-         m_ballShader->SetTexture(SHADER_tex_ball_decal, pball->m_pinballDecal, SF_TRILINEAR, SA_REPEAT, SA_REPEAT, false);
+         m_ballShader->SetTexture(SHADER_tex_ball_decal, pball->m_pinballDecal, SF_TRILINEAR, SA_REPEAT, SA_REPEAT);
       else
          m_ballShader->SetTextureNull(SHADER_tex_ball_decal);
 

--- a/pin3d.cpp
+++ b/pin3d.cpp
@@ -1067,7 +1067,7 @@ void Pin3D::RenderPlayfieldGraphics(const bool depth_only)
        {
            SetPrimaryTextureFilter(0, TEXTURE_MODE_ANISOTROPIC);
            m_pd3dPrimaryDevice->basicShader->SetTechnique(SHADER_TECHNIQUE_basic_depth_only_with_texture);
-           m_pd3dPrimaryDevice->basicShader->SetTexture(SHADER_tex_base_color, pin, SF_TRILINEAR, SA_CLAMP, SA_CLAMP);
+           m_pd3dPrimaryDevice->basicShader->SetTexture(SHADER_tex_base_color, pin, SF_UNDEFINED, SA_CLAMP, SA_CLAMP);
            m_pd3dPrimaryDevice->basicShader->SetAlphaTestValue(pin->m_alphaTestValue * (float)(1.0 / 255.0));
        }
        else // No image by that name
@@ -1081,7 +1081,7 @@ void Pin3D::RenderPlayfieldGraphics(const bool depth_only)
        {
            SetPrimaryTextureFilter(0, TEXTURE_MODE_ANISOTROPIC);
            m_pd3dPrimaryDevice->basicShader->SetTechniqueMetal(SHADER_TECHNIQUE_basic_with_texture, mat->m_bIsMetal);
-           m_pd3dPrimaryDevice->basicShader->SetTexture(SHADER_tex_base_color, pin, SF_TRILINEAR, SA_CLAMP, SA_CLAMP);
+           m_pd3dPrimaryDevice->basicShader->SetTexture(SHADER_tex_base_color, pin, SF_UNDEFINED, SA_CLAMP, SA_CLAMP);
            m_pd3dPrimaryDevice->basicShader->SetAlphaTestValue(pin->m_alphaTestValue * (float)(1.0 / 255.0));
        }
        else // No image by that name

--- a/pin3d.cpp
+++ b/pin3d.cpp
@@ -1067,7 +1067,7 @@ void Pin3D::RenderPlayfieldGraphics(const bool depth_only)
        {
            SetPrimaryTextureFilter(0, TEXTURE_MODE_ANISOTROPIC);
            m_pd3dPrimaryDevice->basicShader->SetTechnique(SHADER_TECHNIQUE_basic_depth_only_with_texture);
-           m_pd3dPrimaryDevice->basicShader->SetTexture(SHADER_tex_base_color, pin, TextureFilter::TEXTURE_MODE_TRILINEAR, true, true, false);
+           m_pd3dPrimaryDevice->basicShader->SetTexture(SHADER_tex_base_color, pin, SF_TRILINEAR, SA_CLAMP, SA_CLAMP, false);
            m_pd3dPrimaryDevice->basicShader->SetAlphaTestValue(pin->m_alphaTestValue * (float)(1.0 / 255.0));
        }
        else // No image by that name
@@ -1081,7 +1081,7 @@ void Pin3D::RenderPlayfieldGraphics(const bool depth_only)
        {
            SetPrimaryTextureFilter(0, TEXTURE_MODE_ANISOTROPIC);
            m_pd3dPrimaryDevice->basicShader->SetTechniqueMetal(SHADER_TECHNIQUE_basic_with_texture, mat->m_bIsMetal);
-           m_pd3dPrimaryDevice->basicShader->SetTexture(SHADER_tex_base_color, pin, TextureFilter::TEXTURE_MODE_TRILINEAR, true, true, false);
+           m_pd3dPrimaryDevice->basicShader->SetTexture(SHADER_tex_base_color, pin, SF_TRILINEAR, SA_CLAMP, SA_CLAMP, false);
            m_pd3dPrimaryDevice->basicShader->SetAlphaTestValue(pin->m_alphaTestValue * (float)(1.0 / 255.0));
        }
        else // No image by that name

--- a/pin3d.cpp
+++ b/pin3d.cpp
@@ -1067,7 +1067,7 @@ void Pin3D::RenderPlayfieldGraphics(const bool depth_only)
        {
            SetPrimaryTextureFilter(0, TEXTURE_MODE_ANISOTROPIC);
            m_pd3dPrimaryDevice->basicShader->SetTechnique(SHADER_TECHNIQUE_basic_depth_only_with_texture);
-           m_pd3dPrimaryDevice->basicShader->SetTexture(SHADER_tex_base_color, pin, SF_TRILINEAR, SA_CLAMP, SA_CLAMP, false);
+           m_pd3dPrimaryDevice->basicShader->SetTexture(SHADER_tex_base_color, pin, SF_TRILINEAR, SA_CLAMP, SA_CLAMP);
            m_pd3dPrimaryDevice->basicShader->SetAlphaTestValue(pin->m_alphaTestValue * (float)(1.0 / 255.0));
        }
        else // No image by that name
@@ -1081,7 +1081,7 @@ void Pin3D::RenderPlayfieldGraphics(const bool depth_only)
        {
            SetPrimaryTextureFilter(0, TEXTURE_MODE_ANISOTROPIC);
            m_pd3dPrimaryDevice->basicShader->SetTechniqueMetal(SHADER_TECHNIQUE_basic_with_texture, mat->m_bIsMetal);
-           m_pd3dPrimaryDevice->basicShader->SetTexture(SHADER_tex_base_color, pin, SF_TRILINEAR, SA_CLAMP, SA_CLAMP, false);
+           m_pd3dPrimaryDevice->basicShader->SetTexture(SHADER_tex_base_color, pin, SF_TRILINEAR, SA_CLAMP, SA_CLAMP);
            m_pd3dPrimaryDevice->basicShader->SetAlphaTestValue(pin->m_alphaTestValue * (float)(1.0 / 255.0));
        }
        else // No image by that name

--- a/plunger.cpp
+++ b/plunger.cpp
@@ -241,7 +241,7 @@ void Plunger::RenderDynamic()
    if (pin)
    {
       pd3dDevice->basicShader->SetTechniqueMetal(SHADER_TECHNIQUE_basic_with_texture, mat->m_bIsMetal);
-      pd3dDevice->basicShader->SetTexture(SHADER_tex_base_color, pin, SF_TRILINEAR, SA_REPEAT, SA_REPEAT);
+      pd3dDevice->basicShader->SetTexture(SHADER_tex_base_color, pin);
       pd3dDevice->basicShader->SetAlphaTestValue(pin->m_alphaTestValue * (float)(1.0 / 255.0));
    }
    else

--- a/plunger.cpp
+++ b/plunger.cpp
@@ -241,7 +241,7 @@ void Plunger::RenderDynamic()
    if (pin)
    {
       pd3dDevice->basicShader->SetTechniqueMetal(SHADER_TECHNIQUE_basic_with_texture, mat->m_bIsMetal);
-      pd3dDevice->basicShader->SetTexture(SHADER_tex_base_color, pin, TextureFilter::TEXTURE_MODE_TRILINEAR, false, false, false);
+      pd3dDevice->basicShader->SetTexture(SHADER_tex_base_color, pin, SF_TRILINEAR, SA_REPEAT, SA_REPEAT, false);
       pd3dDevice->basicShader->SetAlphaTestValue(pin->m_alphaTestValue * (float)(1.0 / 255.0));
    }
    else

--- a/plunger.cpp
+++ b/plunger.cpp
@@ -241,7 +241,7 @@ void Plunger::RenderDynamic()
    if (pin)
    {
       pd3dDevice->basicShader->SetTechniqueMetal(SHADER_TECHNIQUE_basic_with_texture, mat->m_bIsMetal);
-      pd3dDevice->basicShader->SetTexture(SHADER_tex_base_color, pin, SF_TRILINEAR, SA_REPEAT, SA_REPEAT, false);
+      pd3dDevice->basicShader->SetTexture(SHADER_tex_base_color, pin, SF_TRILINEAR, SA_REPEAT, SA_REPEAT);
       pd3dDevice->basicShader->SetAlphaTestValue(pin->m_alphaTestValue * (float)(1.0 / 255.0));
    }
    else

--- a/primitive.cpp
+++ b/primitive.cpp
@@ -1239,7 +1239,7 @@ void Primitive::RenderObject()
       if (g_pplayer->m_texPUP && m_d.m_isBackGlassImage)
       {
          pd3dDevice->basicShader->SetTechniqueMetal(SHADER_TECHNIQUE_basic_with_texture, mat->m_bIsMetal);
-         pd3dDevice->basicShader->SetTexture(SHADER_tex_base_color, pd3dDevice->m_texMan.LoadTexture(g_pplayer->m_texPUP, TextureFilter::TEXTURE_MODE_TRILINEAR, false, false, false));
+         pd3dDevice->basicShader->SetTexture(SHADER_tex_base_color, pd3dDevice->m_texMan.LoadTexture(g_pplayer->m_texPUP, SF_TRILINEAR, SA_REPEAT, SA_REPEAT, false));
 
          //g_pplayer->m_pin3d.SetPrimaryTextureFilter(0, TEXTURE_MODE_TRILINEAR);
          // accommodate models with UV coords outside of [0,1]
@@ -1251,8 +1251,8 @@ void Primitive::RenderObject()
          if (pin && nMap)
          {
             pd3dDevice->basicShader->SetTechniqueMetal(SHADER_TECHNIQUE_basic_with_texture, mat->m_bIsMetal);
-            pd3dDevice->basicShader->SetTexture(SHADER_tex_base_color, pin, TextureFilter::TEXTURE_MODE_TRILINEAR, false, false, false);
-            pd3dDevice->basicShader->SetTexture(SHADER_tex_base_normalmap, nMap, TextureFilter::TEXTURE_MODE_TRILINEAR, false, false, true);
+            pd3dDevice->basicShader->SetTexture(SHADER_tex_base_color, pin, SF_TRILINEAR, SA_REPEAT, SA_REPEAT, false);
+            pd3dDevice->basicShader->SetTexture(SHADER_tex_base_normalmap, nMap, SF_TRILINEAR, SA_REPEAT, SA_REPEAT, true);
             pd3dDevice->basicShader->SetAlphaTestValue(pin->m_alphaTestValue * (float)(1.0 / 255.0));
             pd3dDevice->basicShader->SetBool(SHADER_objectSpaceNormalMap, m_d.m_objectSpaceNormalMap);
             //g_pplayer->m_pin3d.SetPrimaryTextureFilter(0, TEXTURE_MODE_TRILINEAR);
@@ -1262,7 +1262,7 @@ void Primitive::RenderObject()
          else if (pin)
          {
             pd3dDevice->basicShader->SetTechniqueMetal(SHADER_TECHNIQUE_basic_with_texture, mat->m_bIsMetal);
-            pd3dDevice->basicShader->SetTexture(SHADER_tex_base_color, pin, TextureFilter::TEXTURE_MODE_TRILINEAR, false, false, false);
+            pd3dDevice->basicShader->SetTexture(SHADER_tex_base_color, pin, SF_TRILINEAR, SA_REPEAT, SA_REPEAT, false);
             pd3dDevice->basicShader->SetAlphaTestValue(pin->m_alphaTestValue * (float)(1.0 / 255.0));
 
             //g_pplayer->m_pin3d.SetPrimaryTextureFilter(0, TEXTURE_MODE_TRILINEAR);

--- a/primitive.cpp
+++ b/primitive.cpp
@@ -1239,7 +1239,7 @@ void Primitive::RenderObject()
       if (g_pplayer->m_texPUP && m_d.m_isBackGlassImage)
       {
          pd3dDevice->basicShader->SetTechniqueMetal(SHADER_TECHNIQUE_basic_with_texture, mat->m_bIsMetal);
-         pd3dDevice->basicShader->SetTexture(SHADER_tex_base_color, g_pplayer->m_texPUP, SF_TRILINEAR, SA_REPEAT, SA_REPEAT);
+         pd3dDevice->basicShader->SetTexture(SHADER_tex_base_color, g_pplayer->m_texPUP);
 
          //g_pplayer->m_pin3d.SetPrimaryTextureFilter(0, TEXTURE_MODE_TRILINEAR);
          // accommodate models with UV coords outside of [0,1]
@@ -1251,7 +1251,7 @@ void Primitive::RenderObject()
          if (pin && nMap)
          {
             pd3dDevice->basicShader->SetTechniqueMetal(SHADER_TECHNIQUE_basic_with_texture, mat->m_bIsMetal);
-            pd3dDevice->basicShader->SetTexture(SHADER_tex_base_color, pin, SF_TRILINEAR, SA_REPEAT, SA_REPEAT);
+            pd3dDevice->basicShader->SetTexture(SHADER_tex_base_color, pin);
             pd3dDevice->basicShader->SetTexture(SHADER_tex_base_normalmap, nMap, SF_TRILINEAR, SA_REPEAT, SA_REPEAT, true);
             pd3dDevice->basicShader->SetAlphaTestValue(pin->m_alphaTestValue * (float)(1.0 / 255.0));
             pd3dDevice->basicShader->SetBool(SHADER_objectSpaceNormalMap, m_d.m_objectSpaceNormalMap);
@@ -1262,7 +1262,7 @@ void Primitive::RenderObject()
          else if (pin)
          {
             pd3dDevice->basicShader->SetTechniqueMetal(SHADER_TECHNIQUE_basic_with_texture, mat->m_bIsMetal);
-            pd3dDevice->basicShader->SetTexture(SHADER_tex_base_color, pin, SF_TRILINEAR, SA_REPEAT, SA_REPEAT);
+            pd3dDevice->basicShader->SetTexture(SHADER_tex_base_color, pin);
             pd3dDevice->basicShader->SetAlphaTestValue(pin->m_alphaTestValue * (float)(1.0 / 255.0));
 
             //g_pplayer->m_pin3d.SetPrimaryTextureFilter(0, TEXTURE_MODE_TRILINEAR);

--- a/primitive.cpp
+++ b/primitive.cpp
@@ -1239,7 +1239,7 @@ void Primitive::RenderObject()
       if (g_pplayer->m_texPUP && m_d.m_isBackGlassImage)
       {
          pd3dDevice->basicShader->SetTechniqueMetal(SHADER_TECHNIQUE_basic_with_texture, mat->m_bIsMetal);
-         pd3dDevice->basicShader->SetTexture(SHADER_tex_base_color, pd3dDevice->m_texMan.LoadTexture(g_pplayer->m_texPUP, SF_TRILINEAR, SA_REPEAT, SA_REPEAT, false));
+         pd3dDevice->basicShader->SetTexture(SHADER_tex_base_color, g_pplayer->m_texPUP, SF_TRILINEAR, SA_REPEAT, SA_REPEAT);
 
          //g_pplayer->m_pin3d.SetPrimaryTextureFilter(0, TEXTURE_MODE_TRILINEAR);
          // accommodate models with UV coords outside of [0,1]
@@ -1251,7 +1251,7 @@ void Primitive::RenderObject()
          if (pin && nMap)
          {
             pd3dDevice->basicShader->SetTechniqueMetal(SHADER_TECHNIQUE_basic_with_texture, mat->m_bIsMetal);
-            pd3dDevice->basicShader->SetTexture(SHADER_tex_base_color, pin, SF_TRILINEAR, SA_REPEAT, SA_REPEAT, false);
+            pd3dDevice->basicShader->SetTexture(SHADER_tex_base_color, pin, SF_TRILINEAR, SA_REPEAT, SA_REPEAT);
             pd3dDevice->basicShader->SetTexture(SHADER_tex_base_normalmap, nMap, SF_TRILINEAR, SA_REPEAT, SA_REPEAT, true);
             pd3dDevice->basicShader->SetAlphaTestValue(pin->m_alphaTestValue * (float)(1.0 / 255.0));
             pd3dDevice->basicShader->SetBool(SHADER_objectSpaceNormalMap, m_d.m_objectSpaceNormalMap);
@@ -1262,7 +1262,7 @@ void Primitive::RenderObject()
          else if (pin)
          {
             pd3dDevice->basicShader->SetTechniqueMetal(SHADER_TECHNIQUE_basic_with_texture, mat->m_bIsMetal);
-            pd3dDevice->basicShader->SetTexture(SHADER_tex_base_color, pin, SF_TRILINEAR, SA_REPEAT, SA_REPEAT, false);
+            pd3dDevice->basicShader->SetTexture(SHADER_tex_base_color, pin, SF_TRILINEAR, SA_REPEAT, SA_REPEAT);
             pd3dDevice->basicShader->SetAlphaTestValue(pin->m_alphaTestValue * (float)(1.0 / 255.0));
 
             //g_pplayer->m_pin3d.SetPrimaryTextureFilter(0, TEXTURE_MODE_TRILINEAR);

--- a/ramp.cpp
+++ b/ramp.cpp
@@ -923,7 +923,7 @@ void Ramp::RenderStaticHabitrail(const Material * const mat)
       pd3dDevice->basicShader->SetTechniqueMetal(SHADER_TECHNIQUE_basic_without_texture, mat->m_bIsMetal);
    else
    {
-      pd3dDevice->basicShader->SetTexture(SHADER_tex_base_color, pin, SF_TRILINEAR, SA_REPEAT, SA_REPEAT, false);
+      pd3dDevice->basicShader->SetTexture(SHADER_tex_base_color, pin, SF_TRILINEAR, SA_REPEAT, SA_REPEAT);
       pd3dDevice->basicShader->SetTechniqueMetal(SHADER_TECHNIQUE_basic_with_texture, mat->m_bIsMetal);
 
       //g_pplayer->m_pin3d.SetPrimaryTextureFilter(0, TEXTURE_MODE_TRILINEAR);
@@ -2146,7 +2146,7 @@ void Ramp::RenderRamp(const Material * const mat)
       if (pin)
       {
          pd3dDevice->basicShader->SetTechniqueMetal(SHADER_TECHNIQUE_basic_with_texture, mat->m_bIsMetal);
-         pd3dDevice->basicShader->SetTexture(SHADER_tex_base_color, pin, SF_TRILINEAR, SA_REPEAT, SA_REPEAT, false);
+         pd3dDevice->basicShader->SetTexture(SHADER_tex_base_color, pin, SF_TRILINEAR, SA_REPEAT, SA_REPEAT);
          pd3dDevice->basicShader->SetAlphaTestValue(pin->m_alphaTestValue * (float)(1.0 / 255.0));
 
          //ppin3d->SetPrimaryTextureFilter( 0, TEXTURE_MODE_TRILINEAR );

--- a/ramp.cpp
+++ b/ramp.cpp
@@ -923,7 +923,7 @@ void Ramp::RenderStaticHabitrail(const Material * const mat)
       pd3dDevice->basicShader->SetTechniqueMetal(SHADER_TECHNIQUE_basic_without_texture, mat->m_bIsMetal);
    else
    {
-      pd3dDevice->basicShader->SetTexture(SHADER_tex_base_color, pin, TextureFilter::TEXTURE_MODE_TRILINEAR, false, false, false);
+      pd3dDevice->basicShader->SetTexture(SHADER_tex_base_color, pin, SF_TRILINEAR, SA_REPEAT, SA_REPEAT, false);
       pd3dDevice->basicShader->SetTechniqueMetal(SHADER_TECHNIQUE_basic_with_texture, mat->m_bIsMetal);
 
       //g_pplayer->m_pin3d.SetPrimaryTextureFilter(0, TEXTURE_MODE_TRILINEAR);
@@ -2146,7 +2146,7 @@ void Ramp::RenderRamp(const Material * const mat)
       if (pin)
       {
          pd3dDevice->basicShader->SetTechniqueMetal(SHADER_TECHNIQUE_basic_with_texture, mat->m_bIsMetal);
-         pd3dDevice->basicShader->SetTexture(SHADER_tex_base_color, pin, TextureFilter::TEXTURE_MODE_TRILINEAR, false, false, false);
+         pd3dDevice->basicShader->SetTexture(SHADER_tex_base_color, pin, SF_TRILINEAR, SA_REPEAT, SA_REPEAT, false);
          pd3dDevice->basicShader->SetAlphaTestValue(pin->m_alphaTestValue * (float)(1.0 / 255.0));
 
          //ppin3d->SetPrimaryTextureFilter( 0, TEXTURE_MODE_TRILINEAR );

--- a/ramp.cpp
+++ b/ramp.cpp
@@ -923,7 +923,7 @@ void Ramp::RenderStaticHabitrail(const Material * const mat)
       pd3dDevice->basicShader->SetTechniqueMetal(SHADER_TECHNIQUE_basic_without_texture, mat->m_bIsMetal);
    else
    {
-      pd3dDevice->basicShader->SetTexture(SHADER_tex_base_color, pin, SF_TRILINEAR, SA_REPEAT, SA_REPEAT);
+      pd3dDevice->basicShader->SetTexture(SHADER_tex_base_color, pin);
       pd3dDevice->basicShader->SetTechniqueMetal(SHADER_TECHNIQUE_basic_with_texture, mat->m_bIsMetal);
 
       //g_pplayer->m_pin3d.SetPrimaryTextureFilter(0, TEXTURE_MODE_TRILINEAR);
@@ -2146,7 +2146,7 @@ void Ramp::RenderRamp(const Material * const mat)
       if (pin)
       {
          pd3dDevice->basicShader->SetTechniqueMetal(SHADER_TECHNIQUE_basic_with_texture, mat->m_bIsMetal);
-         pd3dDevice->basicShader->SetTexture(SHADER_tex_base_color, pin, SF_TRILINEAR, SA_REPEAT, SA_REPEAT);
+         pd3dDevice->basicShader->SetTexture(SHADER_tex_base_color, pin);
          pd3dDevice->basicShader->SetAlphaTestValue(pin->m_alphaTestValue * (float)(1.0 / 255.0));
 
          //ppin3d->SetPrimaryTextureFilter( 0, TEXTURE_MODE_TRILINEAR );

--- a/rubber.cpp
+++ b/rubber.cpp
@@ -1259,7 +1259,7 @@ void Rubber::RenderObject()
    if (pin)
    {
       pd3dDevice->basicShader->SetTechniqueMetal(SHADER_TECHNIQUE_basic_with_texture, mat->m_bIsMetal);
-      pd3dDevice->basicShader->SetTexture(SHADER_tex_base_color, pin, SF_TRILINEAR, SA_REPEAT, SA_REPEAT, false);
+      pd3dDevice->basicShader->SetTexture(SHADER_tex_base_color, pin, SF_TRILINEAR, SA_REPEAT, SA_REPEAT);
       pd3dDevice->basicShader->SetAlphaTestValue(pin->m_alphaTestValue * (float)(1.0 / 255.0));
    }
    else

--- a/rubber.cpp
+++ b/rubber.cpp
@@ -1259,7 +1259,7 @@ void Rubber::RenderObject()
    if (pin)
    {
       pd3dDevice->basicShader->SetTechniqueMetal(SHADER_TECHNIQUE_basic_with_texture, mat->m_bIsMetal);
-      pd3dDevice->basicShader->SetTexture(SHADER_tex_base_color, pin, SF_TRILINEAR, SA_REPEAT, SA_REPEAT);
+      pd3dDevice->basicShader->SetTexture(SHADER_tex_base_color, pin);
       pd3dDevice->basicShader->SetAlphaTestValue(pin->m_alphaTestValue * (float)(1.0 / 255.0));
    }
    else

--- a/rubber.cpp
+++ b/rubber.cpp
@@ -1259,7 +1259,7 @@ void Rubber::RenderObject()
    if (pin)
    {
       pd3dDevice->basicShader->SetTechniqueMetal(SHADER_TECHNIQUE_basic_with_texture, mat->m_bIsMetal);
-      pd3dDevice->basicShader->SetTexture(SHADER_tex_base_color, pin, TextureFilter::TEXTURE_MODE_TRILINEAR, false, false, false);
+      pd3dDevice->basicShader->SetTexture(SHADER_tex_base_color, pin, SF_TRILINEAR, SA_REPEAT, SA_REPEAT, false);
       pd3dDevice->basicShader->SetAlphaTestValue(pin->m_alphaTestValue * (float)(1.0 / 255.0));
    }
    else

--- a/spinner.cpp
+++ b/spinner.cpp
@@ -386,7 +386,7 @@ void Spinner::RenderDynamic()
    if (image)
    {
       pd3dDevice->basicShader->SetTechniqueMetal(SHADER_TECHNIQUE_basic_with_texture, mat->m_bIsMetal);
-      pd3dDevice->basicShader->SetTexture(SHADER_tex_base_color, image, TextureFilter::TEXTURE_MODE_TRILINEAR, false, false, false);
+      pd3dDevice->basicShader->SetTexture(SHADER_tex_base_color, image, SF_TRILINEAR, SA_REPEAT, SA_REPEAT, false);
       pd3dDevice->basicShader->SetAlphaTestValue(image->m_alphaTestValue * (float)(1.0 / 255.0));
    }
    else // No image by that name

--- a/spinner.cpp
+++ b/spinner.cpp
@@ -386,7 +386,7 @@ void Spinner::RenderDynamic()
    if (image)
    {
       pd3dDevice->basicShader->SetTechniqueMetal(SHADER_TECHNIQUE_basic_with_texture, mat->m_bIsMetal);
-      pd3dDevice->basicShader->SetTexture(SHADER_tex_base_color, image, SF_TRILINEAR, SA_REPEAT, SA_REPEAT, false);
+      pd3dDevice->basicShader->SetTexture(SHADER_tex_base_color, image, SF_TRILINEAR, SA_REPEAT, SA_REPEAT);
       pd3dDevice->basicShader->SetAlphaTestValue(image->m_alphaTestValue * (float)(1.0 / 255.0));
    }
    else // No image by that name

--- a/spinner.cpp
+++ b/spinner.cpp
@@ -386,7 +386,7 @@ void Spinner::RenderDynamic()
    if (image)
    {
       pd3dDevice->basicShader->SetTechniqueMetal(SHADER_TECHNIQUE_basic_with_texture, mat->m_bIsMetal);
-      pd3dDevice->basicShader->SetTexture(SHADER_tex_base_color, image, SF_TRILINEAR, SA_REPEAT, SA_REPEAT);
+      pd3dDevice->basicShader->SetTexture(SHADER_tex_base_color, image);
       pd3dDevice->basicShader->SetAlphaTestValue(image->m_alphaTestValue * (float)(1.0 / 255.0));
    }
    else // No image by that name

--- a/surface.cpp
+++ b/surface.cpp
@@ -1071,7 +1071,7 @@ void Surface::RenderWallsAtHeight(const bool drop)
       if (pinSide)
       {
          pd3dDevice->basicShader->SetTechniqueMetal(SHADER_TECHNIQUE_basic_with_texture, mat->m_bIsMetal);
-         pd3dDevice->basicShader->SetTexture(SHADER_tex_base_color, pinSide, SF_TRILINEAR, SA_REPEAT, SA_REPEAT, false);
+         pd3dDevice->basicShader->SetTexture(SHADER_tex_base_color, pinSide, SF_TRILINEAR, SA_REPEAT, SA_REPEAT);
          pd3dDevice->basicShader->SetAlphaTestValue(pinSide->m_alphaTestValue * (float)(1.0 / 255.0));
 
          //g_pplayer->m_pin3d.SetPrimaryTextureFilter( 0, TEXTURE_MODE_TRILINEAR );
@@ -1103,7 +1103,7 @@ void Surface::RenderWallsAtHeight(const bool drop)
       if (pin)
       {
          pd3dDevice->basicShader->SetTechniqueMetal(SHADER_TECHNIQUE_basic_with_texture, mat->m_bIsMetal);
-         pd3dDevice->basicShader->SetTexture(SHADER_tex_base_color, pin, SF_TRILINEAR, SA_REPEAT, SA_REPEAT, false);
+         pd3dDevice->basicShader->SetTexture(SHADER_tex_base_color, pin, SF_TRILINEAR, SA_REPEAT, SA_REPEAT);
          pd3dDevice->basicShader->SetAlphaTestValue(pin->m_alphaTestValue * (float)(1.0 / 255.0));
 
          //g_pplayer->m_pin3d.SetPrimaryTextureFilter( 0, TEXTURE_MODE_TRILINEAR );

--- a/surface.cpp
+++ b/surface.cpp
@@ -1071,7 +1071,7 @@ void Surface::RenderWallsAtHeight(const bool drop)
       if (pinSide)
       {
          pd3dDevice->basicShader->SetTechniqueMetal(SHADER_TECHNIQUE_basic_with_texture, mat->m_bIsMetal);
-         pd3dDevice->basicShader->SetTexture(SHADER_tex_base_color, pinSide, TextureFilter::TEXTURE_MODE_TRILINEAR, false, false, false);
+         pd3dDevice->basicShader->SetTexture(SHADER_tex_base_color, pinSide, SF_TRILINEAR, SA_REPEAT, SA_REPEAT, false);
          pd3dDevice->basicShader->SetAlphaTestValue(pinSide->m_alphaTestValue * (float)(1.0 / 255.0));
 
          //g_pplayer->m_pin3d.SetPrimaryTextureFilter( 0, TEXTURE_MODE_TRILINEAR );
@@ -1103,7 +1103,7 @@ void Surface::RenderWallsAtHeight(const bool drop)
       if (pin)
       {
          pd3dDevice->basicShader->SetTechniqueMetal(SHADER_TECHNIQUE_basic_with_texture, mat->m_bIsMetal);
-         pd3dDevice->basicShader->SetTexture(SHADER_tex_base_color, pin, TextureFilter::TEXTURE_MODE_TRILINEAR, false, false, false);
+         pd3dDevice->basicShader->SetTexture(SHADER_tex_base_color, pin, SF_TRILINEAR, SA_REPEAT, SA_REPEAT, false);
          pd3dDevice->basicShader->SetAlphaTestValue(pin->m_alphaTestValue * (float)(1.0 / 255.0));
 
          //g_pplayer->m_pin3d.SetPrimaryTextureFilter( 0, TEXTURE_MODE_TRILINEAR );

--- a/surface.cpp
+++ b/surface.cpp
@@ -1071,7 +1071,7 @@ void Surface::RenderWallsAtHeight(const bool drop)
       if (pinSide)
       {
          pd3dDevice->basicShader->SetTechniqueMetal(SHADER_TECHNIQUE_basic_with_texture, mat->m_bIsMetal);
-         pd3dDevice->basicShader->SetTexture(SHADER_tex_base_color, pinSide, SF_TRILINEAR, SA_REPEAT, SA_REPEAT);
+         pd3dDevice->basicShader->SetTexture(SHADER_tex_base_color, pinSide);
          pd3dDevice->basicShader->SetAlphaTestValue(pinSide->m_alphaTestValue * (float)(1.0 / 255.0));
 
          //g_pplayer->m_pin3d.SetPrimaryTextureFilter( 0, TEXTURE_MODE_TRILINEAR );
@@ -1103,7 +1103,7 @@ void Surface::RenderWallsAtHeight(const bool drop)
       if (pin)
       {
          pd3dDevice->basicShader->SetTechniqueMetal(SHADER_TECHNIQUE_basic_with_texture, mat->m_bIsMetal);
-         pd3dDevice->basicShader->SetTexture(SHADER_tex_base_color, pin, SF_TRILINEAR, SA_REPEAT, SA_REPEAT);
+         pd3dDevice->basicShader->SetTexture(SHADER_tex_base_color, pin);
          pd3dDevice->basicShader->SetAlphaTestValue(pin->m_alphaTestValue * (float)(1.0 / 255.0));
 
          //g_pplayer->m_pin3d.SetPrimaryTextureFilter( 0, TEXTURE_MODE_TRILINEAR );

--- a/textbox.cpp
+++ b/textbox.cpp
@@ -302,7 +302,7 @@ void Textbox::RenderDynamic()
          g_pplayer->m_pin3d.EnableAlphaTestReference(0x80);
          g_pplayer->m_pin3d.EnableAlphaBlend(false);
 
-         g_pplayer->Spritedraw(x, y, width, height, 0xFFFFFFFF, pd3dDevice->m_texMan.LoadTexture(m_texture, TextureFilter::TEXTURE_MODE_TRILINEAR, false, false, false), m_d.m_intensity_scale);
+         g_pplayer->Spritedraw(x, y, width, height, 0xFFFFFFFF, pd3dDevice->m_texMan.LoadTexture(m_texture, SF_TRILINEAR, SA_REPEAT, SA_REPEAT, false), m_d.m_intensity_scale);
 
          //pd3dDevice->SetRenderState(RenderDevice::ALPHABLENDENABLE, RenderDevice::RS_FALSE); //!! not necessary anymore
          pd3dDevice->SetRenderState(RenderDevice::ALPHATESTENABLE, RenderDevice::RS_FALSE);


### PR DESCRIPTION
This PR changes the Sampler and TextureManager to default to use the sampling state declared by the Sampler Uniform.

This fixes a few situation were sampling was wrong, it also makes the code fairly simpler, and it prepares for a clean support of anisotropic filtering as a user option.