### PR TITLE
Cleanup all remaining mixed sampler/texture filter state management & add anisotropic filtering

### DIFF
--- a/RenderDevice.h
+++ b/RenderDevice.h
@@ -292,13 +292,9 @@ public:
    void SetRenderStateClipPlane0(const bool enabled);
    void SetRenderStateAlphaTestFunction(const DWORD testValue, const RenderStateValue testFunction, const bool enabled);
 
-   void SetTextureFilter(const DWORD texUnit, DWORD mode);
-   void SetTextureAddressMode(const DWORD texUnit, const SamplerStateValues mode);
 #ifndef ENABLE_SDL
    void SetTextureStageState(const DWORD stage, const D3DTEXTURESTAGESTATETYPE type, const DWORD value);
 #endif
-   void SetSamplerState(const DWORD Sampler, const DWORD minFilter, const DWORD magFilter, const SamplerStateValues mipFilter);
-   void SetSamplerAnisotropy(const DWORD Sampler, DWORD Value);
 
 #ifdef ENABLE_SDL
    HRESULT Create3DFont(INT Height, UINT Width, UINT Weight, UINT MipLevels, BOOL Italic, DWORD CharSet, DWORD OutputPrecision, DWORD Quality, DWORD PitchAndFamily, LPCTSTR pFacename, TTF_Font *ppFont);
@@ -318,7 +314,7 @@ public:
    void SetTransform(const TransformStateType p1, const Matrix3D* p2, const int count = 1);
    void GetTransform(const TransformStateType p1, Matrix3D* p2, const int count = 1);
 
-   void ForceAnisotropicFiltering(const bool enable) { m_force_aniso = enable; }
+   void ForceAnisotropicFiltering(const bool enable);
    void CompressTextures(const bool enable) { m_compress_textures = enable; }
 
    //VR stuff
@@ -447,7 +443,6 @@ public:
 public:
    bool m_autogen_mipmap;
    //bool m_RESZ_support;
-   bool m_force_aniso;
    bool m_compress_textures;
 
 private:

--- a/Sampler.cpp
+++ b/Sampler.cpp
@@ -232,10 +232,6 @@ GLuint Sampler::CreateTexture(UINT Width, UINT Height, UINT Levels, colorFormat 
       glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_SWIZZLE_G, GL_GREEN);
       glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_SWIZZLE_B, GL_BLUE);
       glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_SWIZZLE_A, GL_ALPHA);
-
-      // Anisotropic filtering
-      if (m_rd->m_maxaniso > 0)
-         glTexParameterf(GL_TEXTURE_2D, GL_TEXTURE_MAX_ANISOTROPY, min(max(1.f, m_rd->m_maxaniso), 16.f));
    }
 
    colorFormat comp_format = Format;

--- a/Shader.cpp
+++ b/Shader.cpp
@@ -87,7 +87,7 @@ ShaderTechniques Shader::getTechniqueByName(const string& name)
 #define SHADER_UNIFORM(name) { #name, #name, ""s, -1, SA_UNDEFINED, SA_UNDEFINED, SF_UNDEFINED }
 #define SHADER_TEXTURE(name) { #name, #name, ""s, -1, SA_UNDEFINED, SA_UNDEFINED, SF_UNDEFINED }
 #define SHADER_SAMPLER(name, legacy_name, texture_ref, default_tex_unit, default_clampu, default_clampv, default_filter) { #name, #legacy_name, #texture_ref, default_tex_unit, default_clampu, default_clampv, default_filter }
-const Shader::ShaderUniform Shader::shaderUniformNames[SHADER_UNIFORM_COUNT] {
+Shader::ShaderUniform Shader::shaderUniformNames[SHADER_UNIFORM_COUNT] {
    // -- Floats --
    SHADER_UNIFORM(RenderBall),
    SHADER_UNIFORM(blend_modulate_vs_add),
@@ -198,6 +198,11 @@ ShaderUniforms Shader::getUniformByName(const string& name)
 
    LOG(1, m_shaderCodeName, string("getUniformByName Could not find uniform ").append(name).append(" in shaderUniformNames."));
    return SHADER_UNIFORM_INVALID;
+}
+
+void Shader::SetDefaultSamplerFilter(const ShaderUniforms sampler, const SamplerFilter sf)
+{ 
+   Shader::shaderUniformNames[sampler].default_filter = sf;
 }
 
 // When changed, this list must also be copied unchanged to Shader.cpp (for its implementation)

--- a/Shader.h
+++ b/Shader.h
@@ -258,6 +258,8 @@ public:
    void SetBool(const ShaderUniforms hParameter, const bool b);
    void SetFloatArray(const ShaderUniforms hParameter, const float* pData, const unsigned int count);
 
+   static void SetDefaultSamplerFilter(const ShaderUniforms sampler, const SamplerFilter sf);
+
    static void SetTransform(const TransformStateType p1, const Matrix3D* p2, const int count);
    static void GetTransform(const TransformStateType p1, Matrix3D* p2, const int count);
 
@@ -299,7 +301,7 @@ private:
    };
    static const string Shader::shaderTechniqueNames[SHADER_TECHNIQUE_COUNT];
    static const string Shader::shaderAttributeNames[SHADER_ATTRIBUTE_COUNT];
-   static const ShaderUniform Shader::shaderUniformNames[SHADER_UNIFORM_COUNT];
+   static ShaderUniform Shader::shaderUniformNames[SHADER_UNIFORM_COUNT];
    ShaderUniforms getUniformByName(const string& name);
    ShaderAttributes getAttributeByName(const string& name);
    ShaderTechniques getTechniqueByName(const string& name);

--- a/TextureManager.h
+++ b/TextureManager.h
@@ -8,7 +8,6 @@
 #include "typedefs3D.h"
 
 class RenderDevice;
-enum TextureFilter;
 
 class TextureManager final
 {

--- a/decal.cpp
+++ b/decal.cpp
@@ -553,7 +553,8 @@ void Decal::RenderObject()
             pd3dDevice->basicShader->SetTechniqueMetal(SHADER_TECHNIQUE_basic_with_texture, mat->m_bIsMetal);
          else
             pd3dDevice->basicShader->SetTechnique(SHADER_TECHNIQUE_bg_decal_with_texture);
-         pd3dDevice->basicShader->SetTexture(SHADER_tex_base_color, pin);
+         // Set texture to mirror, so the alpha state of the texture blends correctly to the outside
+         pd3dDevice->basicShader->SetTexture(SHADER_tex_base_color, pin, SF_UNDEFINED, SA_MIRROR, SA_MIRROR);
          pd3dDevice->basicShader->SetAlphaTestValue(pin->m_alphaTestValue * (float)(1.0 / 255.0));
       }
       else
@@ -565,11 +566,6 @@ void Decal::RenderObject()
       }
    }
 
-   // Set texture to mirror, so the alpha state of the texture blends correctly to the outside
-   //!!   pd3dDevice->SetTextureAddressMode(0, RenderDevice::TEX_MIRROR);
-
-   //Pin3D * const ppin3d = &g_pplayer->m_pin3d;
-   //ppin3d->SetPrimaryTextureFilter ( 0, TEXTURE_MODE_TRILINEAR );
    g_pplayer->m_pin3d.EnableAlphaBlend(false);
 
    if (!m_backglass)
@@ -589,7 +585,6 @@ void Decal::RenderObject()
    pd3dDevice->basicShader->End();
 
    // Set the render state.
-   //pd3dDevice->SetTextureAddressMode(0, RenderDevice::TEX_WRAP);
    //pd3dDevice->SetRenderState(RenderDevice::ALPHABLENDENABLE, RenderDevice::RS_FALSE); //!! not necessary anymore
 
    //if(m_backglass && (m_ptable->m_tblMirrorEnabled^m_ptable->m_reflectionEnabled))

--- a/flasher.cpp
+++ b/flasher.cpp
@@ -1247,8 +1247,6 @@ void Flasher::RenderDynamic()
 
           if (!m_d.m_addBlend)
              flasherData.x = pinA->m_alphaTestValue * (float)(1.0/255.0);
-
-          //ppin3d->SetPrimaryTextureFilter( 0, TEXTURE_MODE_TRILINEAR );
        }
        else if (!pinA && pinB)
        {
@@ -1257,8 +1255,6 @@ void Flasher::RenderDynamic()
 
           if (!m_d.m_addBlend)
              flasherData.x = pinB->m_alphaTestValue * (float)(1.0/255.0);
-
-          //ppin3d->SetPrimaryTextureFilter( 0, TEXTURE_MODE_TRILINEAR );
        }
        else if (pinA && pinB)
        {
@@ -1271,8 +1267,6 @@ void Flasher::RenderDynamic()
              flasherData.x = pinA->m_alphaTestValue * (float)(1.0/255.0);
              flasherData.y = pinB->m_alphaTestValue * (float)(1.0/255.0);
           }
-
-          //ppin3d->SetPrimaryTextureFilter( 0, TEXTURE_MODE_TRILINEAR );
        }
        else
           flasherMode = 2.f;

--- a/flipper.cpp
+++ b/flipper.cpp
@@ -610,12 +610,9 @@ void Flipper::RenderDynamic()
    if (pin)
    {
       pd3dDevice->basicShader->SetTechniqueMetal(SHADER_TECHNIQUE_basic_with_texture, mat->m_bIsMetal);
-      pd3dDevice->basicShader->SetTexture(SHADER_tex_base_color, pin);
-      pd3dDevice->basicShader->SetAlphaTestValue(pin->m_alphaTestValue * (float)(1.0 / 255.0));
-
-      //g_pplayer->m_pin3d.SetPrimaryTextureFilter(0, TEXTURE_MODE_TRILINEAR);
       // accomodate models with UV coords outside of [0,1]
-      //pd3dDevice->SetTextureAddressMode(0, RenderDevice::TEX_WRAP);
+      pd3dDevice->basicShader->SetTexture(SHADER_tex_base_color, pin, SF_UNDEFINED, SA_REPEAT, SA_REPEAT);
+      pd3dDevice->basicShader->SetAlphaTestValue(pin->m_alphaTestValue * (float)(1.0 / 255.0));
    }
    else
       pd3dDevice->basicShader->SetTechniqueMetal(SHADER_TECHNIQUE_basic_without_texture, mat->m_bIsMetal);

--- a/hittarget.cpp
+++ b/hittarget.cpp
@@ -707,12 +707,9 @@ void HitTarget::RenderObject()
    if (pin)
    {
       pd3dDevice->basicShader->SetTechniqueMetal(SHADER_TECHNIQUE_basic_with_texture, mat->m_bIsMetal);
-      pd3dDevice->basicShader->SetTexture(SHADER_tex_base_color, pin);
-      pd3dDevice->basicShader->SetAlphaTestValue(pin->m_alphaTestValue * (float)(1.0 / 255.0));
-
-      //g_pplayer->m_pin3d.SetPrimaryTextureFilter(0, TEXTURE_MODE_TRILINEAR);
       // accomodate models with UV coords outside of [0,1]
-      pd3dDevice->SetTextureAddressMode(0, RenderDevice::TEX_WRAP);
+      pd3dDevice->basicShader->SetTexture(SHADER_tex_base_color, pin, SF_UNDEFINED, SA_REPEAT, SA_REPEAT);
+      pd3dDevice->basicShader->SetAlphaTestValue(pin->m_alphaTestValue * (float)(1.0 / 255.0));
    }
    else
       pd3dDevice->basicShader->SetTechniqueMetal(SHADER_TECHNIQUE_basic_without_texture, mat->m_bIsMetal);
@@ -732,7 +729,6 @@ void HitTarget::RenderObject()
    }
 #endif
 
-   pd3dDevice->SetTextureAddressMode(0, RenderDevice::TEX_CLAMP);
    //pd3dDevice->SetRenderState(RenderDevice::ALPHABLENDENABLE, RenderDevice::RS_FALSE); //!! not necessary anymore
    if (m_d.m_disableLightingTop != 0.f || m_d.m_disableLightingBelow != 0.f)
       pd3dDevice->basicShader->SetDisableLighting(vec4(0.f,0.f, 0.f,0.f));

--- a/pin3d.h
+++ b/pin3d.h
@@ -7,15 +7,6 @@
 
 extern int NumVideoBytes;
 
-enum TextureFilter
-{
-   TEXTURE_MODE_NONE,			// No filtering at all, single texel returned.
-   TEXTURE_MODE_POINT,			// Point sampled (aka nearest mipmap) texture filtering.
-   TEXTURE_MODE_BILINEAR,		// Bilinar texture filtering. 
-   TEXTURE_MODE_TRILINEAR,		// Trilinar texture filtering. 
-   TEXTURE_MODE_ANISOTROPIC		// Anisotropic texture filtering. 
-};
-
 enum StereoMode
 {
    STEREO_OFF = 0, // Disabled
@@ -85,10 +76,6 @@ public:
    Vertex3Ds Get3DPointFrom2D(const POINT& p);
 
    void Flip(const bool vsync);
-
-   void SetTextureFilter(RenderDevice * const pd3dDevice, const int TextureNum, const int Mode) const;
-   void SetPrimaryTextureFilter(const int TextureNum, const int Mode) const;
-   void SetSecondaryTextureFilter(const int TextureNum, const int Mode) const;
 
    void EnableAlphaTestReference(const DWORD alphaRefValue) const;
    void EnableAlphaBlend(const bool additiveBlending, const bool set_dest_blend = true, const bool set_blend_op = true) const;

--- a/primitive.cpp
+++ b/primitive.cpp
@@ -1239,11 +1239,8 @@ void Primitive::RenderObject()
       if (g_pplayer->m_texPUP && m_d.m_isBackGlassImage)
       {
          pd3dDevice->basicShader->SetTechniqueMetal(SHADER_TECHNIQUE_basic_with_texture, mat->m_bIsMetal);
-         pd3dDevice->basicShader->SetTexture(SHADER_tex_base_color, g_pplayer->m_texPUP);
-
-         //g_pplayer->m_pin3d.SetPrimaryTextureFilter(0, TEXTURE_MODE_TRILINEAR);
          // accommodate models with UV coords outside of [0,1]
-         pd3dDevice->SetTextureAddressMode(0, RenderDevice::TEX_WRAP);
+         pd3dDevice->basicShader->SetTexture(SHADER_tex_base_color, g_pplayer->m_texPUP, SF_UNDEFINED, SA_REPEAT, SA_REPEAT);
       }
       else
       {
@@ -1251,23 +1248,18 @@ void Primitive::RenderObject()
          if (pin && nMap)
          {
             pd3dDevice->basicShader->SetTechniqueMetal(SHADER_TECHNIQUE_basic_with_texture, mat->m_bIsMetal);
-            pd3dDevice->basicShader->SetTexture(SHADER_tex_base_color, pin);
-            pd3dDevice->basicShader->SetTexture(SHADER_tex_base_normalmap, nMap, SF_TRILINEAR, SA_REPEAT, SA_REPEAT, true);
+            // accommodate models with UV coords outside of [0,1]
+            pd3dDevice->basicShader->SetTexture(SHADER_tex_base_color, pin, SF_UNDEFINED, SA_REPEAT, SA_REPEAT);
+            pd3dDevice->basicShader->SetTexture(SHADER_tex_base_normalmap, nMap, SF_UNDEFINED, SA_REPEAT, SA_REPEAT, true);
             pd3dDevice->basicShader->SetAlphaTestValue(pin->m_alphaTestValue * (float)(1.0 / 255.0));
             pd3dDevice->basicShader->SetBool(SHADER_objectSpaceNormalMap, m_d.m_objectSpaceNormalMap);
-            //g_pplayer->m_pin3d.SetPrimaryTextureFilter(0, TEXTURE_MODE_TRILINEAR);
-            // accommodate models with UV coords outside of [0,1]
-            pd3dDevice->SetTextureAddressMode(0, RenderDevice::TEX_WRAP);
          }
          else if (pin)
          {
             pd3dDevice->basicShader->SetTechniqueMetal(SHADER_TECHNIQUE_basic_with_texture, mat->m_bIsMetal);
-            pd3dDevice->basicShader->SetTexture(SHADER_tex_base_color, pin);
-            pd3dDevice->basicShader->SetAlphaTestValue(pin->m_alphaTestValue * (float)(1.0 / 255.0));
-
-            //g_pplayer->m_pin3d.SetPrimaryTextureFilter(0, TEXTURE_MODE_TRILINEAR);
             // accommodate models with UV coords outside of [0,1]
-            pd3dDevice->SetTextureAddressMode(0, RenderDevice::TEX_WRAP);
+            pd3dDevice->basicShader->SetTexture(SHADER_tex_base_color, pin, SF_UNDEFINED, SA_REPEAT, SA_REPEAT);
+            pd3dDevice->basicShader->SetAlphaTestValue(pin->m_alphaTestValue * (float)(1.0 / 255.0));
          }
          else
             pd3dDevice->basicShader->SetTechniqueMetal(SHADER_TECHNIQUE_basic_without_texture, mat->m_bIsMetal);
@@ -1318,7 +1310,6 @@ void Primitive::RenderObject()
       // reset transform
       g_pplayer->UpdateBasicShaderMatrix();
 
-      pd3dDevice->SetTextureAddressMode(0, RenderDevice::TEX_CLAMP);
       //pd3dDevice->SetRenderState(RenderDevice::ALPHABLENDENABLE, RenderDevice::RS_FALSE); //!! not necessary anymore
       if (m_d.m_disableLightingTop != 0.f || m_d.m_disableLightingBelow != 0.f)
          pd3dDevice->basicShader->SetDisableLighting(vec4(0.f, 0.f, 0.f, 0.f));

--- a/surface.cpp
+++ b/surface.cpp
@@ -1073,8 +1073,6 @@ void Surface::RenderWallsAtHeight(const bool drop)
          pd3dDevice->basicShader->SetTechniqueMetal(SHADER_TECHNIQUE_basic_with_texture, mat->m_bIsMetal);
          pd3dDevice->basicShader->SetTexture(SHADER_tex_base_color, pinSide);
          pd3dDevice->basicShader->SetAlphaTestValue(pinSide->m_alphaTestValue * (float)(1.0 / 255.0));
-
-         //g_pplayer->m_pin3d.SetPrimaryTextureFilter( 0, TEXTURE_MODE_TRILINEAR );
       }
       else
          pd3dDevice->basicShader->SetTechniqueMetal(SHADER_TECHNIQUE_basic_without_texture, mat->m_bIsMetal);
@@ -1105,8 +1103,6 @@ void Surface::RenderWallsAtHeight(const bool drop)
          pd3dDevice->basicShader->SetTechniqueMetal(SHADER_TECHNIQUE_basic_with_texture, mat->m_bIsMetal);
          pd3dDevice->basicShader->SetTexture(SHADER_tex_base_color, pin);
          pd3dDevice->basicShader->SetAlphaTestValue(pin->m_alphaTestValue * (float)(1.0 / 255.0));
-
-         //g_pplayer->m_pin3d.SetPrimaryTextureFilter( 0, TEXTURE_MODE_TRILINEAR );
       }
       else
          pd3dDevice->basicShader->SetTechniqueMetal(SHADER_TECHNIQUE_basic_without_texture, mat->m_bIsMetal);


### PR DESCRIPTION
This PR finally get rid of all the mixed DX7 / DX9 parts regarding texture vs sampler state management, in favor of the new sampler only state management