### PR TITLE
Cleanup remaining legacy texture

### DIFF
--- a/RenderDevice.cpp
+++ b/RenderDevice.cpp
@@ -860,10 +860,6 @@ RenderDevice::RenderDevice(const HWND hwnd, const int width, const int height, c
     currentDeclaration = nullptr;
     //m_curShader = nullptr;
 
-    // fill state caches with dummy values
-    memset(textureStateCache, 0xCC, sizeof(DWORD) * TEXTURE_SAMPLERS * TEXTURE_STATE_CACHE_SIZE);
-    memset(textureSamplerCache, 0xCC, sizeof(DWORD) * TEXTURE_SAMPLERS * TEXTURE_SAMPLER_CACHE_SIZE);
-
     // initialize performance counters
     m_curDrawCalls = m_frameDrawCalls = 0;
     m_curStateChanges = m_frameStateChanges = 0;
@@ -1871,24 +1867,6 @@ GLuint RenderDevice::GetSamplerState(SamplerFilter filter, SamplerAddressMode cl
       }
    }
    return sampler_state;
-}
-#endif
-
-#ifndef ENABLE_SDL
-void RenderDevice::SetTextureStageState(const DWORD p1, const D3DTEXTURESTAGESTATETYPE p2, const DWORD p3)
-{
-   if ((unsigned int)p2 < TEXTURE_STATE_CACHE_SIZE && p1 < TEXTURE_SAMPLERS)
-   {
-      if (textureStateCache[p1][p2] == p3)
-      {
-         // texture stage state hasn't changed since last call of this function -> do nothing here
-         return;
-      }
-      textureStateCache[p1][p2] = p3;
-   }
-   CHECKD3D(m_pD3DDevice->SetTextureStageState(p1, p2, p3));
-
-   m_curStateChanges++;
 }
 #endif
 

--- a/RenderDevice.h
+++ b/RenderDevice.h
@@ -152,15 +152,6 @@ public:
       UNDEFINED
    };
 
-   enum SamplerStateValues {
-      NONE = 0,
-      POINT = 0,
-      LINEAR = 1,
-      TEX_WRAP = GL_REPEAT,
-      TEX_CLAMP = GL_CLAMP_TO_EDGE,
-      TEX_MIRROR = GL_MIRRORED_REPEAT
-   };
-
    enum PrimitiveTypes {
       TRIANGLEFAN = GL_TRIANGLE_FAN,
       TRIANGLESTRIP = GL_TRIANGLE_STRIP,
@@ -231,15 +222,6 @@ public:
       UNDEFINED
    };
 
-   enum SamplerStateValues {
-      NONE = D3DTEXF_NONE,
-      POINT = D3DTEXF_POINT,
-      LINEAR = D3DTEXF_LINEAR,
-      TEX_WRAP = D3DTADDRESS_WRAP,
-      TEX_CLAMP = D3DTADDRESS_CLAMP,
-      TEX_MIRROR = D3DTADDRESS_MIRROR
-   };
-
    enum PrimitiveTypes {
       TRIANGLEFAN = D3DPT_TRIANGLEFAN,
       TRIANGLESTRIP = D3DPT_TRIANGLESTRIP,
@@ -291,10 +273,6 @@ public:
    void SetRenderStateDepthBias(float bias);
    void SetRenderStateClipPlane0(const bool enabled);
    void SetRenderStateAlphaTestFunction(const DWORD testValue, const RenderStateValue testFunction, const bool enabled);
-
-#ifndef ENABLE_SDL
-   void SetTextureStageState(const DWORD stage, const D3DTEXTURESTAGESTATETYPE type, const DWORD value);
-#endif
 
 #ifdef ENABLE_SDL
    HRESULT Create3DFont(INT Height, UINT Width, UINT Weight, UINT MipLevels, BOOL Italic, DWORD CharSet, DWORD OutputPrecision, DWORD Quality, DWORD PitchAndFamily, LPCTSTR pFacename, TTF_Font *ppFont);
@@ -413,13 +391,7 @@ private:
 
    UINT m_adapter;      // index of the display adapter to use
 
-   static constexpr DWORD TEXTURE_SAMPLERS = 8;
-   static constexpr DWORD TEXTURE_STATE_CACHE_SIZE = 256;
-   static constexpr DWORD TEXTURE_SAMPLER_CACHE_SIZE = 14;
-
    DWORD renderStateCache[RENDERSTATE_COUNT];                               // for caching
-   DWORD textureStateCache[TEXTURE_SAMPLERS][TEXTURE_STATE_CACHE_SIZE];     // dto.
-   DWORD textureSamplerCache[TEXTURE_SAMPLERS][TEXTURE_SAMPLER_CACHE_SIZE]; // dto.
 
    VertexDeclaration *currentDeclaration; // for caching
 

--- a/pin3d.cpp
+++ b/pin3d.cpp
@@ -598,12 +598,12 @@ void Pin3D::InitRenderState(RenderDevice * const pd3dDevice)
 
    // initialize first texture stage
 #ifndef ENABLE_SDL
-   pd3dDevice->SetTextureStageState(0, D3DTSS_ALPHAOP, D3DTOP_SELECTARG1);
-   pd3dDevice->SetTextureStageState(0, D3DTSS_ALPHAARG1, D3DTA_TEXTURE);
-   pd3dDevice->SetTextureStageState(0, D3DTSS_TEXCOORDINDEX, 0);
-   pd3dDevice->SetTextureStageState(0, D3DTSS_COLOROP, D3DTOP_MODULATE);
-   pd3dDevice->SetTextureStageState(0, D3DTSS_COLORARG1, D3DTA_TEXTURE);
-   pd3dDevice->SetTextureStageState(0, D3DTSS_COLORARG2, D3DTA_TFACTOR); // default tfactor: 1,1,1,1
+   CHECKD3D(m_pD3DDevice->SetTextureStageState(0, D3DTSS_ALPHAOP, D3DTOP_SELECTARG1));
+   CHECKD3D(m_pD3DDevice->SetTextureStageState(0, D3DTSS_ALPHAARG1, D3DTA_TEXTURE));
+   CHECKD3D(m_pD3DDevice->SetTextureStageState(0, D3DTSS_TEXCOORDINDEX, 0));
+   CHECKD3D(m_pD3DDevice->SetTextureStageState(0, D3DTSS_COLOROP, D3DTOP_MODULATE));
+   CHECKD3D(m_pD3DDevice->SetTextureStageState(0, D3DTSS_COLORARG1, D3DTA_TEXTURE));
+   CHECKD3D(m_pD3DDevice->SetTextureStageState(0, D3DTSS_COLORARG2, D3DTA_TFACTOR)); // default tfactor: 1,1,1,1
 #endif
 }
 


### PR DESCRIPTION
- Move the texture stage initialization to the DX9 state initialization block and cleanup API.
- Remove legacy enums no more used