### PR TITLE
Another pack of improvments

### DIFF
--- a/RenderDevice.cpp
+++ b/RenderDevice.cpp
@@ -1257,7 +1257,7 @@ void RenderDevice::CreateDevice(int &refreshrate, UINT adapterIndex)
          m_pMirrorTmpBufferTexture = new RenderTarget(this, m_width_aa, m_height_aa, render_format, false, 1, STEREO_OFF, "Fatal Error: unable to create mirror buffer!");
    }
 
-   // alloc bloom tex at 1/3 x 1/3 res (allows for simple HQ downscale of clipped input while saving memory)
+   // alloc bloom tex at 1/4 x 1/4 res (allows for simple HQ downscale of clipped input while saving memory)
    m_pBloomBufferTexture = new RenderTarget(this, m_width / 4, m_height / 4, render_format, false, 1, STEREO_OFF, "Fatal Error: unable to create bloom buffer!");
 
    // temporary buffer for gaussian blur
@@ -1290,13 +1290,13 @@ void RenderDevice::CreateDevice(int &refreshrate, UINT adapterIndex)
 
    // alloc temporary buffer for stereo3D/post-processing AA/sharpen
    if ((m_stereo3D != STEREO_OFF) || (m_FXAA > 0) || m_sharpen)
-      m_pOffscreenBackBufferTmpTexture = new RenderTarget(this, m_width, m_height, video10bit ? colorFormat::RGBA10 : colorFormat::RGBA8, false, 1, STEREO_OFF, "Fatal Error: unable to create stereo3D/post-processing AA/sharpen buffer!");
+      m_pOffscreenBackBufferTmpTexture = new RenderTarget(this, m_width, m_height, video10bit ? colorFormat::RGB10 : colorFormat::RGB8, false, 1, STEREO_OFF, "Fatal Error: unable to create stereo3D/post-processing AA/sharpen buffer!");
    else
       m_pOffscreenBackBufferTmpTexture = nullptr;
 
    // alloc one more temporary buffer for SMAA
    if (m_FXAA == Quality_SMAA)
-      m_pOffscreenBackBufferTmpTexture2 = new RenderTarget(this, m_width, m_height, video10bit ? colorFormat::RGBA10 : colorFormat::RGBA8, false, 1, STEREO_OFF, "Fatal Error: unable to create SMAA buffer!");
+      m_pOffscreenBackBufferTmpTexture2 = new RenderTarget(this, m_width, m_height, video10bit ? colorFormat::RGB10 : colorFormat::RGB8, false, 1, STEREO_OFF, "Fatal Error: unable to create SMAA buffer!");
    else
       m_pOffscreenBackBufferTmpTexture2 = nullptr;
 

--- a/RenderDevice.cpp
+++ b/RenderDevice.cpp
@@ -1539,20 +1539,18 @@ RenderDevice::~RenderDevice()
    SAFE_RELEASE(m_pVertexTrafoTexelDeclaration);
 
    m_texMan.UnloadAll();
-   delete m_pOffscreenBackBufferTexture;
-   delete m_pOffscreenBackBufferTmpTexture;
-   delete m_pOffscreenBackBufferTmpTexture2;
+   delete m_pBackBuffer;
+   if (m_pOffscreenBackBufferTexture != m_pOffscreenMSAABackBufferTexture)
+      delete m_pOffscreenBackBufferTexture;
+   delete m_pOffscreenMSAABackBufferTexture;
    delete m_pReflectionBufferTexture;
-
-   if (g_pplayer)
-   {
-      const bool drawBallReflection = ((g_pplayer->m_reflectionForBalls && (g_pplayer->m_ptable->m_useReflectionForBalls == -1)) || (g_pplayer->m_ptable->m_useReflectionForBalls == 1));
-      if ((g_pplayer->m_ptable->m_reflectElementsOnPlayfield /*&& g_pplayer->m_pf_refl*/) || drawBallReflection)
-         delete m_pMirrorTmpBufferTexture;
-   }
+   delete m_pMirrorTmpBufferTexture;
    delete m_pBloomBufferTexture;
    delete m_pBloomTmpBufferTexture;
-   delete m_pBackBuffer;
+   delete m_pOffscreenVRLeft;
+   delete m_pOffscreenVRRight;
+   delete m_pOffscreenBackBufferTmpTexture;
+   delete m_pOffscreenBackBufferTmpTexture2;
 
    delete m_SMAAareaTexture;
    delete m_SMAAsearchTexture;
@@ -1593,31 +1591,31 @@ RenderDevice::~RenderDevice()
       delete binding;
    m_samplerBindings.clear();
 #ifdef ENABLE_VR
-    if (m_pHMD)
-    {
-        turnVROff();
-        SaveValueFloat(regKey[RegName::Player], "VRSlope"s, m_slope);
-        SaveValueFloat(regKey[RegName::Player], "VROrientation"s, m_orientation);
-        SaveValueFloat(regKey[RegName::Player], "VRTableX"s, m_tablex);
-        SaveValueFloat(regKey[RegName::Player], "VRTableY"s, m_tabley);
-        SaveValueFloat(regKey[RegName::Player], "VRTableZ"s, m_tablez);
-        SaveValueFloat(regKey[RegName::Player], "VRRoomOrientation"s, m_roomOrientation);
-        SaveValueFloat(regKey[RegName::Player], "VRRoomX"s, m_roomx);
-        SaveValueFloat(regKey[RegName::Player], "VRRoomY"s, m_roomy);
-    }
+   if (m_pHMD)
+   {
+      turnVROff();
+      SaveValueFloat(regKey[RegName::Player], "VRSlope"s, m_slope);
+      SaveValueFloat(regKey[RegName::Player], "VROrientation"s, m_orientation);
+      SaveValueFloat(regKey[RegName::Player], "VRTableX"s, m_tablex);
+      SaveValueFloat(regKey[RegName::Player], "VRTableY"s, m_tabley);
+      SaveValueFloat(regKey[RegName::Player], "VRTableZ"s, m_tablez);
+      SaveValueFloat(regKey[RegName::Player], "VRRoomOrientation"s, m_roomOrientation);
+      SaveValueFloat(regKey[RegName::Player], "VRRoomX"s, m_roomx);
+      SaveValueFloat(regKey[RegName::Player], "VRRoomY"s, m_roomy);
+   }
 #endif
 
-    for (int i = 0; i < 3 * 3 * 5; i++)
-    {
-       if (m_samplerStateCache[i] != 0)
-       {
-          glDeleteSamplers(1, &m_samplerStateCache[i]);
-          m_samplerStateCache[i] = 0;
-       }
-    }
+   for (int i = 0; i < 3 * 3 * 5; i++)
+   {
+      if (m_samplerStateCache[i] != 0)
+      {
+         glDeleteSamplers(1, &m_samplerStateCache[i]);
+         m_samplerStateCache[i] = 0;
+      }
+   }
 
-    SDL_GL_DeleteContext(m_sdl_context);
-    SDL_DestroyWindow(m_sdl_playfieldHwnd);
+   SDL_GL_DeleteContext(m_sdl_context);
+   SDL_DestroyWindow(m_sdl_playfieldHwnd);
 #endif
 }
 

--- a/RenderDevice.h
+++ b/RenderDevice.h
@@ -90,30 +90,26 @@ class Shader;
 class RenderDevice final
 {
 public:
-
-#ifdef ENABLE_SDL
+#define RENDER_STATE(name, bitpos, bitsize) name,
+   // These definition must be copy/pasted to RenderDevice.h/cpp when modified to keep the implementation in sync
    enum RenderStates
    {
-      ALPHABLENDENABLE,
-      ZENABLE,
-      DEPTHBIAS,
-      ALPHATESTENABLE,
-      ALPHAREF,
-      ALPHAFUNC,
-      BLENDOP,
-      CLIPPING,
-      CLIPPLANEENABLE,
-      CULLMODE,
-      DESTBLEND,
-      LIGHTING,
-      SRCBLEND,
-      SRGBWRITEENABLE,
-      ZFUNC,
-      ZWRITEENABLE,
-      COLORWRITEENABLE,
+      RENDER_STATE(ALPHABLENDENABLE, 0, 1) // RS_FALSE or RS_TRUE
+      RENDER_STATE(ZENABLE, 1, 1) // RS_FALSE or RS_TRUE
+      RENDER_STATE(ALPHATESTENABLE, 2, 1) // RS_FALSE or RS_TRUE
+      RENDER_STATE(ALPHAFUNC, 3, 3) // Operation from Z_ALWAYS, Z_LESS, Z_LESSEQUAL, Z_GREATER, Z_GREATEREQUAL
+      RENDER_STATE(BLENDOP, 6, 2) // Operation from BLENDOP_MAX, BLENDOP_ADD, BLENDOP_SUB, BLENDOP_REVSUBTRACT
+      RENDER_STATE(CLIPPLANEENABLE, 8, 1) // PLANE0 or 0 (for disable)
+      RENDER_STATE(CULLMODE, 9, 2) // CULL_NONE, CULL_CW, CULL_CCW
+      RENDER_STATE(DESTBLEND, 11, 3) // ZERO, ONE, SRC_ALPHA, DST_ALPHA, INVSRC_ALPHA, INVSRC_COLOR
+      RENDER_STATE(SRCBLEND, 14, 3) // ZERO, ONE, SRC_ALPHA, DST_ALPHA, INVSRC_ALPHA, INVSRC_COLOR
+      RENDER_STATE(ZFUNC, 17, 3) // Operation from Z_ALWAYS, Z_LESS, Z_LESSEQUAL, Z_GREATER, Z_GREATEREQUAL
+      RENDER_STATE(ZWRITEENABLE, 20, 1) // RS_FALSE or RS_TRUE
+      RENDER_STATE(COLORWRITEENABLE, 21, 4) // RGBA mask (4 bits)
       RENDERSTATE_COUNT,
       RENDERSTATE_INVALID
    };
+#undef RENDER_STATE
 
    enum RenderStateValue
    {
@@ -122,35 +118,37 @@ public:
       RS_TRUE = 1,
       //Culling
       CULL_NONE = 0,
-      CULL_CW = GL_CW,
-      CULL_CCW = GL_CCW,
+      CULL_CW = 1,
+      CULL_CCW = 2,
       //Depth functions
-      Z_ALWAYS = GL_ALWAYS,
-      Z_LESS = GL_LESS,
-      Z_LESSEQUAL = GL_LEQUAL,
-      Z_GREATER = GL_GREATER,
-      Z_GREATEREQUAL = GL_GEQUAL,
+      Z_ALWAYS = 0,
+      Z_LESS = 1,
+      Z_LESSEQUAL = 2,
+      Z_GREATER = 3,
+      Z_GREATEREQUAL = 4,
       //Blending ops
-      BLENDOP_MAX = GL_MAX,
-      BLENDOP_ADD = GL_FUNC_ADD,
-      BLENDOP_SUB = GL_FUNC_SUBTRACT,
-      BLENDOP_REVSUBTRACT = GL_FUNC_REVERSE_SUBTRACT,
+      BLENDOP_MAX = 0,
+      BLENDOP_ADD = 1,
+      BLENDOP_REVSUBTRACT = 2,
       //Blending values
-      ZERO = GL_ZERO,
-      ONE = GL_ONE,
-      SRC_ALPHA = GL_SRC_ALPHA,
-      DST_ALPHA = GL_DST_ALPHA,
-      SRC_COLOR = GL_SRC_COLOR,
-      DST_COLOR = GL_DST_COLOR,
-      INVSRC_ALPHA = GL_ONE_MINUS_SRC_ALPHA,
-      INVSRC_COLOR = GL_ONE_MINUS_SRC_COLOR,
+      ZERO = 0,
+      ONE = 1,
+      SRC_ALPHA = 2,
+      DST_ALPHA = 3,
+      INVSRC_ALPHA = 4,
+      INVSRC_COLOR = 5,
       //Clipping planes
       PLANE0 = 1,
+      //Color mask
+      RGBMASK_NONE = 0x00000000u,
+      RGBMASK_RGBA = 0x0000000Fu,
 
       UNDEFINED
    };
 
-   enum PrimitiveTypes {
+#ifdef ENABLE_SDL
+   enum PrimitiveTypes
+   {
       TRIANGLEFAN = GL_TRIANGLE_FAN,
       TRIANGLESTRIP = GL_TRIANGLE_STRIP,
       TRIANGLELIST = GL_TRIANGLES,
@@ -159,68 +157,11 @@ public:
       LINESTRIP = GL_LINE_STRIP
    };
 
-   SDL_Window *m_sdl_playfieldHwnd;
-   SDL_GLContext  m_sdl_context;
-
+   SDL_Window* m_sdl_playfieldHwnd;
+   SDL_GLContext m_sdl_context;
 #else
-
-   enum RenderStates
+   enum PrimitiveTypes
    {
-      ALPHABLENDENABLE = D3DRS_ALPHABLENDENABLE,
-      ALPHATESTENABLE = D3DRS_ALPHATESTENABLE,
-      ALPHAREF = D3DRS_ALPHAREF,
-      ALPHAFUNC = D3DRS_ALPHAFUNC,
-      BLENDOP = D3DRS_BLENDOP,
-      CLIPPING = D3DRS_CLIPPING,
-      CLIPPLANEENABLE = D3DRS_CLIPPLANEENABLE,
-      CULLMODE = D3DRS_CULLMODE,
-      DESTBLEND = D3DRS_DESTBLEND,
-      LIGHTING = D3DRS_LIGHTING,
-      SRCBLEND = D3DRS_SRCBLEND,
-      SRGBWRITEENABLE = D3DRS_SRGBWRITEENABLE,
-      ZENABLE = D3DRS_ZENABLE,
-      ZFUNC = D3DRS_ZFUNC,
-      ZWRITEENABLE = D3DRS_ZWRITEENABLE,
-      TEXTUREFACTOR = D3DRS_TEXTUREFACTOR,
-      DEPTHBIAS = D3DRS_DEPTHBIAS,
-      COLORWRITEENABLE = D3DRS_COLORWRITEENABLE,
-      RENDERSTATE_COUNT,
-      RENDERSTATE_INVALID
-   };
-
-   enum RenderStateValue
-   {
-      //Booleans
-      RS_FALSE = FALSE,
-      RS_TRUE = TRUE,
-      //Culling
-      CULL_NONE = D3DCULL_NONE,
-      CULL_CW = D3DCULL_CW,
-      CULL_CCW = D3DCULL_CCW,
-      //Depth functions
-      Z_ALWAYS = D3DCMP_ALWAYS,
-      Z_LESS = D3DCMP_LESS,
-      Z_LESSEQUAL = D3DCMP_LESSEQUAL,
-      Z_GREATER = D3DCMP_GREATER,
-      Z_GREATEREQUAL = D3DCMP_GREATEREQUAL,
-      //Blending ops
-      BLENDOP_MAX = D3DBLENDOP_MAX,
-      BLENDOP_ADD = D3DBLENDOP_ADD,
-      BLENDOP_REVSUBTRACT = D3DBLENDOP_REVSUBTRACT,
-      //Blending values
-      ZERO = D3DBLEND_ZERO,
-      ONE = D3DBLEND_ONE,
-      SRC_ALPHA = D3DBLEND_SRCALPHA,
-      DST_ALPHA = D3DBLEND_DESTALPHA,
-      INVSRC_ALPHA = D3DBLEND_INVSRCALPHA,
-      INVSRC_COLOR = D3DBLEND_INVSRCCOLOR,
-      //Clipping planes
-      PLANE0 = D3DCLIPPLANE0,
-
-      UNDEFINED
-   };
-
-   enum PrimitiveTypes {
       TRIANGLEFAN = D3DPT_TRIANGLEFAN,
       TRIANGLESTRIP = D3DPT_TRIANGLESTRIP,
       TRIANGLELIST = D3DPT_TRIANGLELIST,
@@ -229,7 +170,6 @@ public:
       LINESTRIP = D3DPT_LINESTRIP
    };
 #endif
-
 
    RenderDevice(const HWND hwnd, const int width, const int height, const bool fullscreen, const int colordepth, int VSync, const float AAfactor, const StereoMode stereo3D, const unsigned int FXAA, const bool sharpen, const bool ss_refl, const bool useNvidiaApi, const bool disable_dwm, const int BWrendering);
    ~RenderDevice();
@@ -265,13 +205,31 @@ public:
 
    bool DepthBufferReadBackAvailable();
 
-   void SetRenderState(const RenderStates p1, DWORD p2);
-   bool SetRenderStateCache(const RenderStates p1, DWORD p2);
+   struct RenderStateCache
+   {
+      unsigned int state;
+      float depth_bias;
+      DWORD alpha_ref;
+   };
+   void SetRenderState(const RenderStates p1, const RenderStateValue p2);
    void SetRenderStateCulling(RenderStateValue cull);
    void SetRenderStateDepthBias(float bias);
    void SetRenderStateClipPlane0(const bool enabled);
    void SetRenderStateAlphaTestFunction(const DWORD testValue, const RenderStateValue testFunction, const bool enabled);
+   void CopyRenderStates(const bool copyTo, RenderStateCache& state);
+   void ApplyRenderStates();
 
+private:
+   struct RenderStateMask
+   {
+      uint32_t shift;
+      uint32_t mask;
+      uint32_t clear_mask;
+   };
+   static const RenderStateMask render_state_masks[RENDERSTATE_COUNT];
+   RenderStateCache m_current_renderstate, m_renderstate;
+
+public:
 #ifdef ENABLE_SDL
    HRESULT Create3DFont(INT Height, UINT Width, UINT Weight, UINT MipLevels, BOOL Italic, DWORD CharSet, DWORD OutputPrecision, DWORD Quality, DWORD PitchAndFamily, LPCTSTR pFacename, TTF_Font *ppFont);
 #else

--- a/RenderTarget.cpp
+++ b/RenderTarget.cpp
@@ -10,6 +10,9 @@
 #include "nvapi.h"
 #endif
 
+RenderTarget* RenderTarget::current_render_target = nullptr;
+RenderTarget* RenderTarget::GetCurrentRenderTarget() { return current_render_target; }
+
 RenderTarget::RenderTarget(RenderDevice* rd, int width, int height)
 {
    m_rd = rd;
@@ -263,6 +266,7 @@ void RenderTarget::CopyTo(RenderTarget* dest)
 
 void RenderTarget::Activate(bool ignoreStereo)
 {
+   current_render_target = this;
 #ifdef ENABLE_SDL
    static GLfloat viewPorts[] = { 0.0f, 0.0f, 0.0f, 0.0f, 0.0f, 0.0f, 0.0f, 0.0f };
    static RenderTarget* currentFrameBuffer = nullptr;

--- a/RenderTarget.h
+++ b/RenderTarget.h
@@ -11,6 +11,7 @@ public:
    ~RenderTarget();
 
    void Activate(const bool ignoreStereo);
+   static RenderTarget* GetCurrentRenderTarget();
 
    Sampler* GetColorSampler() { return m_color_sampler; }
    void UpdateDepthSampler();
@@ -43,6 +44,7 @@ private:
    bool m_is_back_buffer;
    bool m_has_depth;
    int m_nMSAASamples;
+   static RenderTarget* current_render_target;
 
 #ifdef ENABLE_SDL
    GLuint m_framebuffer;

--- a/Shader.cpp
+++ b/Shader.cpp
@@ -84,9 +84,9 @@ ShaderTechniques Shader::getTechniqueByName(const string& name)
    return SHADER_TECHNIQUE_INVALID;
 }
 
-#define SHADER_UNIFORM(name) { #name, #name, ""s, -1, SA_UNDEFINED, SA_UNDEFINED, SF_UNDEFINED }
-#define SHADER_TEXTURE(name) { #name, #name, ""s, -1, SA_UNDEFINED, SA_UNDEFINED, SF_UNDEFINED }
-#define SHADER_SAMPLER(name, legacy_name, texture_ref, default_tex_unit, default_clampu, default_clampv, default_filter) { #name, #legacy_name, #texture_ref, default_tex_unit, default_clampu, default_clampv, default_filter }
+#define SHADER_UNIFORM(name) { false, #name, #name, ""s, -1, SA_UNDEFINED, SA_UNDEFINED, SF_UNDEFINED }
+#define SHADER_TEXTURE(name) { true, #name, #name, ""s, -1, SA_UNDEFINED, SA_UNDEFINED, SF_UNDEFINED }
+#define SHADER_SAMPLER(name, legacy_name, texture_ref, default_tex_unit, default_clampu, default_clampv, default_filter) { true, #name, #legacy_name, #texture_ref, default_tex_unit, default_clampu, default_clampv, default_filter }
 Shader::ShaderUniform Shader::shaderUniformNames[SHADER_UNIFORM_COUNT] {
    // -- Floats --
    SHADER_UNIFORM(RenderBall),
@@ -232,9 +232,9 @@ Shader* Shader::GetCurrentShader() { return current_shader;  }
 Shader::Shader(RenderDevice *renderDevice) : currentMaterial(-FLT_MAX, -FLT_MAX, -FLT_MAX, -FLT_MAX, -FLT_MAX, -FLT_MAX, -FLT_MAX, 0xCCCCCCCC, 0xCCCCCCCC, 0xCCCCCCCC, false, false, -FLT_MAX, -FLT_MAX, -FLT_MAX, -FLT_MAX)
 {
    m_renderDevice = renderDevice;
+   m_technique = SHADER_TECHNIQUE_INVALID;
 #ifdef ENABLE_SDL
    logFile = nullptr;
-   m_technique = SHADER_TECHNIQUE_INVALID;
    memset(m_uniformCache, 0, sizeof(UniformCache) * SHADER_UNIFORM_COUNT * (SHADER_TECHNIQUE_COUNT + 1));
    memset(m_techniques, 0, sizeof(ShaderTechnique*) * SHADER_TECHNIQUE_COUNT);
    memset(m_isCacheValid, 0, sizeof(bool) * SHADER_TECHNIQUE_COUNT);
@@ -265,8 +265,8 @@ void Shader::Begin()
 {
    assert(current_shader == nullptr);
    current_shader = this;
-#ifdef ENABLE_SDL
    assert(m_technique != SHADER_TECHNIQUE_INVALID);
+#ifdef ENABLE_SDL
    static ShaderTechniques bound_technique = ShaderTechniques::SHADER_TECHNIQUE_INVALID;
    if (bound_technique != m_technique)
    {
@@ -299,7 +299,7 @@ void Shader::End()
 #endif
 }
 
-void Shader::SetMaterial(const Material * const mat, const bool has_alpha)
+void Shader::SetMaterial(const Material* const mat, const bool has_alpha)
 {
    COLORREF cBase, cGlossy, cClearcoat;
    float fWrapLighting, fRoughness, fGlossyImageLerp, fThickness, fEdge, fEdgeAlpha, fOpacity;

--- a/Shader.cpp
+++ b/Shader.cpp
@@ -299,7 +299,7 @@ void Shader::End()
 #endif
 }
 
-void Shader::SetMaterial(const Material * const mat)
+void Shader::SetMaterial(const Material * const mat, const bool has_alpha)
 {
    COLORREF cBase, cGlossy, cClearcoat;
    float fWrapLighting, fRoughness, fGlossyImageLerp, fThickness, fEdge, fEdgeAlpha, fOpacity;
@@ -379,7 +379,7 @@ void Shader::SetMaterial(const Material * const mat)
       currentMaterial.m_fEdgeAlpha = fEdgeAlpha;
    }
 
-   if (bOpacityActive /*&& (alpha < 1.0f)*/)
+   if (bOpacityActive && (has_alpha || alpha < 1.0f))
       g_pplayer->m_pin3d.EnableAlphaBlend(false);
    else
       g_pplayer->m_pin3d.m_pd3dPrimaryDevice->SetRenderState(RenderDevice::ALPHABLENDENABLE, RenderDevice::RS_FALSE);

--- a/Shader.h
+++ b/Shader.h
@@ -141,7 +141,7 @@ enum ShaderUniforms
    SHADER_UNIFORM(objectSpaceNormalMap),
    SHADER_UNIFORM(do_dither),
    SHADER_UNIFORM(imageBackglassMode),
-   // -- Textures --
+   // FIXME -- Legacy Textures (to be removed) --
    SHADER_TEXTURE(Texture0),
    SHADER_TEXTURE(Texture1),
    SHADER_TEXTURE(Texture2),
@@ -233,7 +233,7 @@ public:
    void SetTexture(const ShaderUniforms texelName, Texture* texel, const SamplerFilter filter = SF_UNDEFINED, const SamplerAddressMode clampU = SA_UNDEFINED, const SamplerAddressMode clampV = SA_UNDEFINED, const bool force_linear_rgb = false);
    void SetTexture(const ShaderUniforms texelName, Sampler* texel);
    void SetTextureNull(const ShaderUniforms texelName);
-   void SetMaterial(const Material * const mat);
+   void SetMaterial(const Material * const mat, const bool has_alpha = true);
 
    void SetDisableLighting(const float value); // only set top
    void SetDisableLighting(const vec4& value); // set top and below

--- a/Shader.h
+++ b/Shader.h
@@ -266,6 +266,24 @@ public:
 
    static Shader* GetCurrentShader();
 
+#ifdef ENABLE_SDL
+   // state of what is actually bound per technique, and what is expected for the next begin/end
+   struct UniformCache
+   {
+      size_t count; // number of elements for uniform blocks and float vectors
+      size_t capacity; // size of the datablock
+      float* data; // uniform blocks & large float vectors data block
+      union UniformValue
+      {
+         int i; // integer and boolean
+         float f; // float value
+         float fv[16]; // float vectors and matrices
+         Sampler* sampler; // texture samplers
+      } val;
+   };
+   uint32_t CopyUniformCache(const bool copyTo, const ShaderTechniques technique, UniformCache (&m_uniformCache)[SHADER_UNIFORM_COUNT]);
+#endif
+
 private:
    RenderDevice* m_renderDevice;
    static Shader* current_shader;
@@ -292,6 +310,7 @@ private:
 
    struct ShaderUniform
    {
+      bool is_sampler;
       string name;
       string legacy_name;
       string texture_ref;
@@ -342,20 +361,6 @@ private:
 
    void ApplyUniform(const ShaderUniforms uniformName);
 
-   // state of what is actually bound per technique, and what is expected for the next begin/end
-   struct floatP
-   {
-      size_t count;
-      float* data;
-   };
-   union UniformCache
-   {
-      int ival; // integer and booleans
-      float fval; // floats
-      float fvval[16]; // float vectors and matrices
-      floatP fp; // uniform blocks
-      Sampler* sampler; // texture samplers
-   };
    std::vector<ShaderUniforms> m_uniforms[SHADER_TECHNIQUE_COUNT];
    bool m_isCacheValid[SHADER_TECHNIQUE_COUNT];
    UniformCache m_uniformCache[SHADER_TECHNIQUE_COUNT + 1][SHADER_UNIFORM_COUNT];

--- a/Shader.h
+++ b/Shader.h
@@ -248,6 +248,7 @@ public:
 
    void SetTechnique(const ShaderTechniques technique);
    void SetTechniqueMetal(const ShaderTechniques technique, const bool isMetal);
+   ShaderTechniques GetCurrentTechnique() { return m_technique; }
 
    void SetMatrix(const ShaderUniforms hParameter, const Matrix3D* pMatrix);
    void SetUniformBlock(const ShaderUniforms hParameter, const float* pMatrix, const size_t size);

--- a/bumper.cpp
+++ b/bumper.cpp
@@ -296,9 +296,8 @@ void Bumper::RenderBase(const Material * const baseMaterial)
 {
    RenderDevice * const pd3dDevice = g_pplayer->m_pin3d.m_pd3dPrimaryDevice;
 
-   pd3dDevice->basicShader->SetMaterial(baseMaterial);
+   pd3dDevice->basicShader->SetMaterial(baseMaterial, false);
    pd3dDevice->basicShader->SetTexture(SHADER_tex_base_color, &m_baseTexture);
-   g_pplayer->m_pin3d.EnableAlphaBlend(false);
    pd3dDevice->basicShader->SetAlphaTestValue((float)(1.0 / 255.0));
 
    pd3dDevice->basicShader->Begin();
@@ -310,9 +309,8 @@ void Bumper::RenderSocket(const Material * const socketMaterial)
 {
    RenderDevice * const pd3dDevice = g_pplayer->m_pin3d.m_pd3dPrimaryDevice;
 
-   pd3dDevice->basicShader->SetMaterial(socketMaterial);
+   pd3dDevice->basicShader->SetMaterial(socketMaterial, false);
    pd3dDevice->basicShader->SetTexture(SHADER_tex_base_color, &m_skirtTexture);
-   g_pplayer->m_pin3d.EnableAlphaBlend(false);
    pd3dDevice->basicShader->SetAlphaTestValue((float)(1.0 / 255.0));
 
    pd3dDevice->basicShader->Begin();
@@ -324,9 +322,8 @@ void Bumper::RenderCap(const Material * const capMaterial)
 {
    RenderDevice * const pd3dDevice = g_pplayer->m_pin3d.m_pd3dPrimaryDevice;
 
-   pd3dDevice->basicShader->SetMaterial(capMaterial);
+   pd3dDevice->basicShader->SetMaterial(capMaterial, false);
    pd3dDevice->basicShader->SetTexture(SHADER_tex_base_color, &m_capTexture);
-   g_pplayer->m_pin3d.EnableAlphaBlend(false);
    pd3dDevice->basicShader->SetAlphaTestValue((float)(1.0 / 255.0));
 
    pd3dDevice->basicShader->Begin();
@@ -463,7 +460,7 @@ void Bumper::RenderDynamic()
 
       pd3dDevice->basicShader->SetTechniqueMetal(SHADER_TECHNIQUE_basic_with_texture, ringMaterial.m_bIsMetal);
       pd3dDevice->basicShader->SetTexture(SHADER_tex_base_color, &m_ringTexture);
-      pd3dDevice->basicShader->SetMaterial(&ringMaterial);
+      pd3dDevice->basicShader->SetMaterial(&ringMaterial, false);
       pd3dDevice->basicShader->SetAlphaTestValue(-1.0f);
 
       // render ring

--- a/dialogs/Properties/DragpointVisualsProperty.cpp
+++ b/dialogs/Properties/DragpointVisualsProperty.cpp
@@ -72,22 +72,27 @@ void DragpointVisualsProperty::UpdateProperties(const int dispid)
         switch (dispid)
         {
             case 1:
-                CHECK_UPDATE_ITEM(dpoint->m_v.x, PropertyDialog::GetFloatTextbox(m_posXEdit), dpoint);
+                if (m_posXEdit.IsWindow() && !m_posXEdit.GetWindowText().IsEmpty())
+                    CHECK_UPDATE_ITEM(dpoint->m_v.x, PropertyDialog::GetFloatTextbox(m_posXEdit), dpoint);
                 break;
             case 2:
-                CHECK_UPDATE_ITEM(dpoint->m_v.y, PropertyDialog::GetFloatTextbox(m_posYEdit), dpoint);
+                if (m_posYEdit.IsWindow() && !m_posYEdit.GetWindowText().IsEmpty())
+                    CHECK_UPDATE_ITEM(dpoint->m_v.y, PropertyDialog::GetFloatTextbox(m_posYEdit), dpoint);
                 break;
             case 4:
                 CHECK_UPDATE_ITEM(dpoint->m_autoTexture, PropertyDialog::GetCheckboxState(::GetDlgItem(GetHwnd(), 4)), dpoint);
                 break;
             case 5:
-                CHECK_UPDATE_ITEM(dpoint->m_texturecoord, PropertyDialog::GetFloatTextbox(m_textureCoordEdit), dpoint);
+                if (m_textureCoordEdit.IsWindow() && !m_textureCoordEdit.GetWindowText().IsEmpty())
+                    CHECK_UPDATE_ITEM(dpoint->m_texturecoord, PropertyDialog::GetFloatTextbox(m_textureCoordEdit), dpoint);
                 break;
             case 6:
-                CHECK_UPDATE_ITEM(dpoint->m_v.z, PropertyDialog::GetFloatTextbox(m_heightOffsetEdit), dpoint);
+                if (m_heightOffsetEdit.IsWindow() && !m_heightOffsetEdit.GetWindowText().IsEmpty())
+                    CHECK_UPDATE_ITEM(dpoint->m_v.z, PropertyDialog::GetFloatTextbox(m_heightOffsetEdit), dpoint);
                 break;
             case IDC_CALC_HEIGHT_EDIT:
-                CHECK_UPDATE_ITEM(dpoint->m_calcHeight, PropertyDialog::GetFloatTextbox(m_realHeightEdit), dpoint);
+                if (m_realHeightEdit.IsWindow() && !m_realHeightEdit.GetWindowText().IsEmpty())
+                    CHECK_UPDATE_ITEM(dpoint->m_calcHeight, PropertyDialog::GetFloatTextbox(m_realHeightEdit), dpoint);
                 break;
             default:
                 break;

--- a/dialogs/Properties/PropertyDialog.cpp
+++ b/dialogs/Properties/PropertyDialog.cpp
@@ -411,13 +411,20 @@ void PropertyDialog::DeleteAllTabs()
 
 void PropertyDialog::UpdateTextureComboBox(const vector<Texture *>& contentList, const CComboBox &combo, const string &selectName)
 {
-    bool texelFound = false;
-    for (const auto texel : contentList)
-    {
-        if (strncmp(texel->m_szName.c_str(), selectName.c_str(), MAXTOKEN) == 0) //!! _stricmp?
+   bool need_reset = combo.GetCount() != contentList.size() + 1; // Not the same number of items
+   need_reset |= combo.FindStringExact(1, selectName.c_str()) == CB_ERR; // Selection is not part of combo
+   if (!need_reset)
+   {
+      bool texelFound = false;
+      for (const auto texel : contentList)
+      {
+         if (strncmp(texel->m_szName.c_str(), selectName.c_str(), MAXTOKEN) == 0) //!! _stricmp?
             texelFound = true;
-    }
-    if (combo.FindStringExact(1, selectName.c_str()) == CB_ERR || !texelFound)
+         need_reset |= combo.FindStringExact(1, texel->m_szName.c_str()) == CB_ERR; // Combo does not contain an image from the image list
+      }
+      need_reset |= !texelFound; // Selection is not part of image list
+   }
+   if (need_reset)
     {
         combo.ResetContent();
         combo.AddString(_T("<None>"));

--- a/flipper.cpp
+++ b/flipper.cpp
@@ -604,7 +604,6 @@ void Flipper::RenderDynamic()
       return;
 
    const Material * mat = m_ptable->GetMaterial(m_d.m_szMaterial);
-   pd3dDevice->basicShader->SetMaterial(mat);
 
    Texture * const pin = m_ptable->GetImage(m_d.m_szImage);
    if (pin)
@@ -613,9 +612,13 @@ void Flipper::RenderDynamic()
       // accomodate models with UV coords outside of [0,1]
       pd3dDevice->basicShader->SetTexture(SHADER_tex_base_color, pin, SF_UNDEFINED, SA_REPEAT, SA_REPEAT);
       pd3dDevice->basicShader->SetAlphaTestValue(pin->m_alphaTestValue * (float)(1.0 / 255.0));
+      pd3dDevice->basicShader->SetMaterial(mat, pin->m_pdsBuffer->has_alpha());
    }
    else
+   {
       pd3dDevice->basicShader->SetTechniqueMetal(SHADER_TECHNIQUE_basic_without_texture, mat->m_bIsMetal);
+      pd3dDevice->basicShader->SetMaterial(mat, false);
+   }
 
    pd3dDevice->SetRenderStateDepthBias(0.0f);
    pd3dDevice->SetRenderState(RenderDevice::ZWRITEENABLE, RenderDevice::RS_TRUE);
@@ -641,10 +644,15 @@ void Flipper::RenderDynamic()
    {
       mat = m_ptable->GetMaterial(m_d.m_szRubberMaterial);
       if (pin)
-        pd3dDevice->basicShader->SetTechniqueMetal(SHADER_TECHNIQUE_basic_with_texture, mat->m_bIsMetal);
+      {
+         pd3dDevice->basicShader->SetTechniqueMetal(SHADER_TECHNIQUE_basic_with_texture, mat->m_bIsMetal);
+         pd3dDevice->basicShader->SetMaterial(mat, pin->m_pdsBuffer->has_alpha());
+      }
       else
-        pd3dDevice->basicShader->SetTechniqueMetal(SHADER_TECHNIQUE_basic_without_texture, mat->m_bIsMetal);
-      pd3dDevice->basicShader->SetMaterial(mat);
+      {
+         pd3dDevice->basicShader->SetTechniqueMetal(SHADER_TECHNIQUE_basic_without_texture, mat->m_bIsMetal);
+         pd3dDevice->basicShader->SetMaterial(mat, false);
+      }
 
       pd3dDevice->basicShader->Begin();
       pd3dDevice->DrawIndexedPrimitiveVB(RenderDevice::TRIANGLELIST, MY_D3DFVF_NOTEX2_VERTEX, m_vertexBuffer, flipperBaseVertices, flipperBaseVertices, m_indexBuffer, 0, flipperBaseNumIndices);

--- a/gate.cpp
+++ b/gate.cpp
@@ -444,10 +444,7 @@ void Gate::RenderObject()
    RenderDevice * const pd3dDevice = g_pplayer->m_pin3d.m_pd3dPrimaryDevice;
 
    const Material * const mat = m_ptable->GetMaterial(m_d.m_szMaterial);
-   pd3dDevice->basicShader->SetMaterial(mat);
-
-   const Pin3D * const ppin3d = &g_pplayer->m_pin3d;
-   ppin3d->EnableAlphaBlend(false);
+   pd3dDevice->basicShader->SetMaterial(mat, false);
 
    pd3dDevice->SetRenderStateDepthBias(0.0f);
    pd3dDevice->SetRenderState(RenderDevice::ZWRITEENABLE, RenderDevice::RS_TRUE);

--- a/hittarget.cpp
+++ b/hittarget.cpp
@@ -690,7 +690,6 @@ void HitTarget::RenderObject()
    RenderDevice * const pd3dDevice = g_pplayer->m_pin3d.m_pd3dPrimaryDevice;
 
    const Material * const mat = m_ptable->GetMaterial(m_d.m_szMaterial);
-   pd3dDevice->basicShader->SetMaterial(mat);
 
    pd3dDevice->SetRenderStateDepthBias(0.0f);
    pd3dDevice->SetRenderState(RenderDevice::ZWRITEENABLE, RenderDevice::RS_TRUE);
@@ -710,9 +709,13 @@ void HitTarget::RenderObject()
       // accomodate models with UV coords outside of [0,1]
       pd3dDevice->basicShader->SetTexture(SHADER_tex_base_color, pin, SF_UNDEFINED, SA_REPEAT, SA_REPEAT);
       pd3dDevice->basicShader->SetAlphaTestValue(pin->m_alphaTestValue * (float)(1.0 / 255.0));
+      pd3dDevice->basicShader->SetMaterial(mat, pin->m_pdsBuffer->has_alpha());
    }
    else
+   {
       pd3dDevice->basicShader->SetTechniqueMetal(SHADER_TECHNIQUE_basic_without_texture, mat->m_bIsMetal);
+      pd3dDevice->basicShader->SetMaterial(mat, false);
+   }
 
    // draw the mesh
    pd3dDevice->basicShader->Begin();

--- a/light.cpp
+++ b/light.cpp
@@ -422,8 +422,8 @@ void Light::RenderDynamic()
 
    if (m_backglass && !GetPTable()->GetDecalsEnabled())
       return;
-
-   if (m_d.m_BulbLight && m_d.m_showBulbMesh && !m_d.m_staticBulbMesh)
+      
+   if (m_d.m_BulbLight && m_d.m_showBulbMesh && !m_d.m_staticBulbMesh && g_pplayer->m_current_renderstage == 0)
       RenderBulbMesh();
 
    Texture *offTexel = nullptr;

--- a/light.cpp
+++ b/light.cpp
@@ -347,7 +347,7 @@ void Light::RenderBulbMesh()
    RenderDevice * const pd3dDevice = m_backglass ? g_pplayer->m_pin3d.m_pd3dSecondaryDevice : g_pplayer->m_pin3d.m_pd3dPrimaryDevice;
 
    pd3dDevice->basicShader->SetTechniqueMetal(SHADER_TECHNIQUE_basic_without_texture, mat.m_bIsMetal);
-   pd3dDevice->basicShader->SetMaterial(&mat);
+   pd3dDevice->basicShader->SetMaterial(&mat, false);
 
    pd3dDevice->basicShader->Begin();
    pd3dDevice->DrawIndexedPrimitiveVB(RenderDevice::TRIANGLELIST, MY_D3DFVF_NOTEX2_VERTEX, m_bulbSocketVBuffer, 0, bulbSocketNumVertices, m_bulbSocketIndexBuffer, 0, bulbSocketNumFaces);
@@ -366,7 +366,7 @@ void Light::RenderBulbMesh()
    mat.m_fThickness = 0.05f;
    mat.m_cClearcoat = 0xFFFFFF;
    pd3dDevice->basicShader->SetTechniqueMetal(SHADER_TECHNIQUE_basic_without_texture, mat.m_bIsMetal);
-   pd3dDevice->basicShader->SetMaterial(&mat);
+   pd3dDevice->basicShader->SetMaterial(&mat, false);
 
    pd3dDevice->basicShader->Begin();
    pd3dDevice->DrawIndexedPrimitiveVB(RenderDevice::TRIANGLELIST, MY_D3DFVF_NOTEX2_VERTEX, m_bulbLightVBuffer, 0, bulbLightNumVertices, m_bulbLightIndexBuffer, 0, bulbLightNumFaces);

--- a/pin3d.cpp
+++ b/pin3d.cpp
@@ -1050,16 +1050,18 @@ void Pin3D::RenderPlayfieldGraphics(const bool depth_only)
    }
    else
    {
-       m_pd3dPrimaryDevice->basicShader->SetMaterial(mat);
-
        if (pin)
        {
            m_pd3dPrimaryDevice->basicShader->SetTechniqueMetal(SHADER_TECHNIQUE_basic_with_texture, mat->m_bIsMetal);
            m_pd3dPrimaryDevice->basicShader->SetTexture(SHADER_tex_base_color, pin, SF_ANISOTROPIC, SA_CLAMP, SA_CLAMP);
            m_pd3dPrimaryDevice->basicShader->SetAlphaTestValue(pin->m_alphaTestValue * (float)(1.0 / 255.0));
+           m_pd3dPrimaryDevice->basicShader->SetMaterial(mat, pin->m_pdsBuffer->has_alpha());
        }
        else // No image by that name
-           m_pd3dPrimaryDevice->basicShader->SetTechniqueMetal(SHADER_TECHNIQUE_basic_without_texture, mat->m_bIsMetal);
+       {
+          m_pd3dPrimaryDevice->basicShader->SetTechniqueMetal(SHADER_TECHNIQUE_basic_without_texture, mat->m_bIsMetal);
+          m_pd3dPrimaryDevice->basicShader->SetMaterial(mat, false);
+       }
    }
 
    if (!g_pplayer->m_meshAsPlayfield)

--- a/pin3d.cpp
+++ b/pin3d.cpp
@@ -586,17 +586,16 @@ void Pin3D::InitRenderState(RenderDevice * const pd3dDevice)
 {
    pd3dDevice->SetRenderState(RenderDevice::ALPHABLENDENABLE, RenderDevice::RS_FALSE);
 
-   pd3dDevice->SetRenderState(RenderDevice::LIGHTING, RenderDevice::RS_FALSE);
-
    pd3dDevice->SetRenderState(RenderDevice::ZENABLE, RenderDevice::RS_TRUE);
    pd3dDevice->SetRenderState(RenderDevice::ZWRITEENABLE, RenderDevice::RS_TRUE);
    pd3dDevice->SetRenderStateCulling(RenderDevice::CULL_CCW);
 
-   pd3dDevice->SetRenderState(RenderDevice::CLIPPING, RenderDevice::RS_FALSE);
    pd3dDevice->SetRenderStateClipPlane0(false);
 
-   // initialize first texture stage
 #ifndef ENABLE_SDL
+   CHECKD3D(m_pD3DDevice->SetRenderState(D3DRS_LIGHTING, FALSE);
+   CHECKD3D(m_pD3DDevice->SetRenderState(D3DRS_CLIPPING, FALSE);
+   // initialize first texture stage
    CHECKD3D(m_pD3DDevice->SetTextureStageState(0, D3DTSS_ALPHAOP, D3DTOP_SELECTARG1));
    CHECKD3D(m_pD3DDevice->SetTextureStageState(0, D3DTSS_ALPHAARG1, D3DTA_TEXTURE));
    CHECKD3D(m_pD3DDevice->SetTextureStageState(0, D3DTSS_TEXCOORDINDEX, 0));
@@ -1038,7 +1037,7 @@ void Pin3D::RenderPlayfieldGraphics(const bool depth_only)
 
    if (depth_only)
    {
-       m_pd3dPrimaryDevice->SetRenderState(RenderDevice::COLORWRITEENABLE, 0); //m_pin3d.m_pd3dPrimaryDevice->SetPrimaryRenderTarget(nullptr); // disable color writes
+       m_pd3dPrimaryDevice->SetRenderState(RenderDevice::COLORWRITEENABLE, RenderDevice::RGBMASK_NONE); //m_pin3d.m_pd3dPrimaryDevice->SetPrimaryRenderTarget(nullptr); // disable color writes
        // even with depth-only rendering we have to take care of alpha textures (stencil playfield to see underlying objects)
        if (pin)
        {
@@ -1087,7 +1086,7 @@ void Pin3D::RenderPlayfieldGraphics(const bool depth_only)
    }
 
    if (depth_only)
-       m_pd3dPrimaryDevice->SetRenderState(RenderDevice::COLORWRITEENABLE, 0x0000000Fu); // reenable color writes with default value
+      m_pd3dPrimaryDevice->SetRenderState(RenderDevice::COLORWRITEENABLE, RenderDevice::RGBMASK_RGBA); // reenable color writes with default value
 
    // Apparently, releasing the vertex buffer here immediately can cause rendering glitches in
    // later rendering steps, so we keep it around for now.

--- a/plunger.cpp
+++ b/plunger.cpp
@@ -231,8 +231,6 @@ void Plunger::RenderDynamic()
 
    RenderDevice * const pd3dDevice = g_pplayer->m_pin3d.m_pd3dPrimaryDevice;
 
-   pd3dDevice->basicShader->SetMaterial(mat);
-
    pd3dDevice->SetRenderStateDepthBias(0.0f);
    pd3dDevice->SetRenderState(RenderDevice::ZWRITEENABLE, RenderDevice::RS_TRUE);
    pd3dDevice->SetRenderStateCulling(RenderDevice::CULL_CCW);
@@ -243,9 +241,13 @@ void Plunger::RenderDynamic()
       pd3dDevice->basicShader->SetTechniqueMetal(SHADER_TECHNIQUE_basic_with_texture, mat->m_bIsMetal);
       pd3dDevice->basicShader->SetTexture(SHADER_tex_base_color, pin);
       pd3dDevice->basicShader->SetAlphaTestValue(pin->m_alphaTestValue * (float)(1.0 / 255.0));
+      pd3dDevice->basicShader->SetMaterial(mat, pin->m_pdsBuffer->has_alpha());
    }
    else
+   {
       pd3dDevice->basicShader->SetTechniqueMetal(SHADER_TECHNIQUE_basic_without_texture, mat->m_bIsMetal);
+      pd3dDevice->basicShader->SetMaterial(mat, false);
+   }
 
    pd3dDevice->basicShader->Begin();
    pd3dDevice->DrawIndexedPrimitiveVB(RenderDevice::TRIANGLELIST, MY_D3DFVF_NOTEX2_VERTEX, m_vertexBuffer,

--- a/primitive.cpp
+++ b/primitive.cpp
@@ -1225,7 +1225,6 @@ void Primitive::RenderObject()
    if (!m_d.m_useAsPlayfield)
    {
       const Material * const mat = m_ptable->GetMaterial(m_d.m_szMaterial);
-      pd3dDevice->basicShader->SetMaterial(mat);
 
       pd3dDevice->SetRenderStateDepthBias(0.f);
       pd3dDevice->SetRenderState(RenderDevice::ZWRITEENABLE, RenderDevice::RS_TRUE);
@@ -1253,6 +1252,7 @@ void Primitive::RenderObject()
             pd3dDevice->basicShader->SetTexture(SHADER_tex_base_normalmap, nMap, SF_UNDEFINED, SA_REPEAT, SA_REPEAT, true);
             pd3dDevice->basicShader->SetAlphaTestValue(pin->m_alphaTestValue * (float)(1.0 / 255.0));
             pd3dDevice->basicShader->SetBool(SHADER_objectSpaceNormalMap, m_d.m_objectSpaceNormalMap);
+            pd3dDevice->basicShader->SetMaterial(mat, pin->m_pdsBuffer->has_alpha());
          }
          else if (pin)
          {
@@ -1260,9 +1260,13 @@ void Primitive::RenderObject()
             // accommodate models with UV coords outside of [0,1]
             pd3dDevice->basicShader->SetTexture(SHADER_tex_base_color, pin, SF_UNDEFINED, SA_REPEAT, SA_REPEAT);
             pd3dDevice->basicShader->SetAlphaTestValue(pin->m_alphaTestValue * (float)(1.0 / 255.0));
+            pd3dDevice->basicShader->SetMaterial(mat, pin->m_pdsBuffer->has_alpha());
          }
          else
+         {
             pd3dDevice->basicShader->SetTechniqueMetal(SHADER_TECHNIQUE_basic_without_texture, mat->m_bIsMetal);
+            pd3dDevice->basicShader->SetMaterial(mat, false);
+         }
       }
 
       pd3dDevice->basicShader->SetBool(SHADER_doNormalMapping, nMap);

--- a/ramp.cpp
+++ b/ramp.cpp
@@ -917,19 +917,21 @@ void Ramp::RenderStaticHabitrail(const Material * const mat)
     * since the texture coordinates always stay within [0,1] anyway. */
    SamplerAddressMode sam = m_d.m_imagealignment == ImageModeWrap ? SA_CLAMP : SA_REPEAT;
 
-   pd3dDevice->basicShader->SetMaterial(mat);
-
    pd3dDevice->SetRenderStateDepthBias(0.0f);
    pd3dDevice->SetRenderState(RenderDevice::ZWRITEENABLE, RenderDevice::RS_TRUE);
    pd3dDevice->SetRenderStateCulling(RenderDevice::CULL_NONE);
 
    Texture * const pin = m_ptable->GetImage(m_d.m_szImage);
    if (!pin)
+   {
       pd3dDevice->basicShader->SetTechniqueMetal(SHADER_TECHNIQUE_basic_without_texture, mat->m_bIsMetal);
+      pd3dDevice->basicShader->SetMaterial(mat, false);
+   }
    else
    {
       pd3dDevice->basicShader->SetTexture(SHADER_tex_base_color, pin, SF_UNDEFINED, sam, sam);
       pd3dDevice->basicShader->SetTechniqueMetal(SHADER_TECHNIQUE_basic_with_texture, mat->m_bIsMetal);
+      pd3dDevice->basicShader->SetMaterial(mat, pin->m_pdsBuffer->has_alpha());
    }
 
    if ((m_d.m_type == RampType2Wire) || (m_d.m_type == RampType4Wire))
@@ -2125,8 +2127,6 @@ void Ramp::RenderRamp(const Material * const mat)
       if (!m_dynamicVertexBuffer || m_dynamicVertexBufferRegenerate)
          GenerateVertexBuffer();
 
-      pd3dDevice->basicShader->SetMaterial(mat);
-
       pd3dDevice->SetRenderStateDepthBias(0.0f);
       pd3dDevice->SetRenderState(RenderDevice::ZWRITEENABLE, RenderDevice::RS_TRUE);
       pd3dDevice->SetRenderStateCulling(RenderDevice::CULL_NONE); // as both floor and walls are thinwalled
@@ -2144,9 +2144,13 @@ void Ramp::RenderRamp(const Material * const mat)
          pd3dDevice->basicShader->SetTechniqueMetal(SHADER_TECHNIQUE_basic_with_texture, mat->m_bIsMetal);
          pd3dDevice->basicShader->SetTexture(SHADER_tex_base_color, pin, SF_UNDEFINED, sam, sam);
          pd3dDevice->basicShader->SetAlphaTestValue(pin->m_alphaTestValue * (float)(1.0 / 255.0));
+         pd3dDevice->basicShader->SetMaterial(mat, pin->m_pdsBuffer->has_alpha());
       }
       else
+      {
          pd3dDevice->basicShader->SetTechniqueMetal(SHADER_TECHNIQUE_basic_without_texture, mat->m_bIsMetal);
+         pd3dDevice->basicShader->SetMaterial(mat, false);
+      }
 
       //ppin3d->EnableAlphaBlend( false ); //!! not necessary anymore
 

--- a/rubber.cpp
+++ b/rubber.cpp
@@ -1249,7 +1249,6 @@ void Rubber::RenderObject()
    RenderDevice * const pd3dDevice = g_pplayer->m_pin3d.m_pd3dPrimaryDevice;
 
    const Material * const mat = m_ptable->GetMaterial(m_d.m_szMaterial);
-   pd3dDevice->basicShader->SetMaterial(mat);
 
    pd3dDevice->SetRenderStateDepthBias(0.0f);
    pd3dDevice->SetRenderState(RenderDevice::ZWRITEENABLE, RenderDevice::RS_TRUE);
@@ -1261,9 +1260,13 @@ void Rubber::RenderObject()
       pd3dDevice->basicShader->SetTechniqueMetal(SHADER_TECHNIQUE_basic_with_texture, mat->m_bIsMetal);
       pd3dDevice->basicShader->SetTexture(SHADER_tex_base_color, pin);
       pd3dDevice->basicShader->SetAlphaTestValue(pin->m_alphaTestValue * (float)(1.0 / 255.0));
+      pd3dDevice->basicShader->SetMaterial(mat, pin->m_pdsBuffer->has_alpha());
    }
    else
+   {
       pd3dDevice->basicShader->SetTechniqueMetal(SHADER_TECHNIQUE_basic_without_texture, mat->m_bIsMetal);
+      pd3dDevice->basicShader->SetMaterial(mat, false);
+   }
 
    pd3dDevice->basicShader->Begin();
    pd3dDevice->DrawIndexedPrimitiveVB(RenderDevice::TRIANGLELIST, MY_D3DFVF_NOTEX2_VERTEX, m_dynamicVertexBuffer, 0, m_numVertices, m_dynamicIndexBuffer, 0, m_numIndices);

--- a/spinner.cpp
+++ b/spinner.cpp
@@ -376,7 +376,6 @@ void Spinner::RenderDynamic()
    UpdatePlate(nullptr);
 
    const Material * const mat = m_ptable->GetMaterial(m_d.m_szMaterial);
-   pd3dDevice->basicShader->SetMaterial(mat);
 
    pd3dDevice->SetRenderStateDepthBias(0.0f);
    pd3dDevice->SetRenderState(RenderDevice::ZWRITEENABLE, RenderDevice::RS_TRUE);
@@ -388,9 +387,13 @@ void Spinner::RenderDynamic()
       pd3dDevice->basicShader->SetTechniqueMetal(SHADER_TECHNIQUE_basic_with_texture, mat->m_bIsMetal);
       pd3dDevice->basicShader->SetTexture(SHADER_tex_base_color, image);
       pd3dDevice->basicShader->SetAlphaTestValue(image->m_alphaTestValue * (float)(1.0 / 255.0));
+      pd3dDevice->basicShader->SetMaterial(mat, image->m_pdsBuffer->has_alpha());
    }
    else // No image by that name
+   {
       pd3dDevice->basicShader->SetTechniqueMetal(SHADER_TECHNIQUE_basic_without_texture, mat->m_bIsMetal);
+      pd3dDevice->basicShader->SetMaterial(mat, false);
+   }
 
    pd3dDevice->basicShader->Begin();
    pd3dDevice->DrawIndexedPrimitiveVB(RenderDevice::TRIANGLELIST, MY_D3DFVF_NOTEX2_VERTEX, m_plateVertexBuffer, 0, spinnerPlateNumVertices, m_plateIndexBuffer, 0, spinnerPlateNumFaces);
@@ -471,9 +474,8 @@ void Spinner::RenderStatic()
    mat.m_cClearcoat = 0x20202020;
    mat.m_fEdge = 1.0f;
    mat.m_fEdgeAlpha = 1.0f;
-   pd3dDevice->basicShader->SetMaterial(&mat);
+   pd3dDevice->basicShader->SetMaterial(&mat, false);
    pd3dDevice->basicShader->SetTechniqueMetal(SHADER_TECHNIQUE_basic_without_texture, mat.m_bIsMetal);
-   ppin3d->EnableAlphaBlend(false);
 
    pd3dDevice->basicShader->Begin();
    pd3dDevice->DrawIndexedPrimitiveVB(RenderDevice::TRIANGLELIST, MY_D3DFVF_NOTEX2_VERTEX, m_bracketVertexBuffer, 0, spinnerBracketNumVertices, m_bracketIndexBuffer, 0, spinnerBracketNumFaces);

--- a/surface.cpp
+++ b/surface.cpp
@@ -1090,7 +1090,6 @@ void Surface::RenderWallsAtHeight(const bool drop)
    if (m_d.m_topBottomVisible && (m_numPolys > 0))
    {
       const Material * const mat = m_ptable->GetMaterial(m_d.m_szTopMaterial);
-      pd3dDevice->basicShader->SetMaterial(mat);
 
       pd3dDevice->SetRenderStateDepthBias(0.0f);
       pd3dDevice->SetRenderState(RenderDevice::ZWRITEENABLE, RenderDevice::RS_TRUE);

--- a/surface.cpp
+++ b/surface.cpp
@@ -1009,7 +1009,7 @@ void Surface::RenderSlingshots()
 
    const Material * const mat = m_ptable->GetMaterial(m_d.m_szSlingShotMaterial);
    pd3dDevice->basicShader->SetTechniqueMetal(SHADER_TECHNIQUE_basic_without_texture, mat->m_bIsMetal);
-   pd3dDevice->basicShader->SetMaterial(mat);
+   pd3dDevice->basicShader->SetMaterial(mat, false);
 
    pd3dDevice->SetRenderStateDepthBias(0.0f);
    pd3dDevice->SetRenderState(RenderDevice::ZWRITEENABLE, RenderDevice::RS_TRUE);
@@ -1053,7 +1053,6 @@ void Surface::RenderWallsAtHeight(const bool drop)
    if (m_d.m_sideVisible && !drop && (m_numVertices > 0)) // Don't need to render walls if dropped
    {
       const Material * const mat = m_ptable->GetMaterial(m_d.m_szSideMaterial);
-      pd3dDevice->basicShader->SetMaterial(mat);
 
       pd3dDevice->SetRenderStateDepthBias(0.0f);
       pd3dDevice->SetRenderState(RenderDevice::ZWRITEENABLE, RenderDevice::RS_TRUE);
@@ -1073,9 +1072,13 @@ void Surface::RenderWallsAtHeight(const bool drop)
          pd3dDevice->basicShader->SetTechniqueMetal(SHADER_TECHNIQUE_basic_with_texture, mat->m_bIsMetal);
          pd3dDevice->basicShader->SetTexture(SHADER_tex_base_color, pinSide);
          pd3dDevice->basicShader->SetAlphaTestValue(pinSide->m_alphaTestValue * (float)(1.0 / 255.0));
+         pd3dDevice->basicShader->SetMaterial(mat, pinSide->m_pdsBuffer->has_alpha());
       }
       else
+      {
          pd3dDevice->basicShader->SetTechniqueMetal(SHADER_TECHNIQUE_basic_without_texture, mat->m_bIsMetal);
+         pd3dDevice->basicShader->SetMaterial(mat, false);
+      }
 
       // combine drawcalls into one (hopefully faster)
       pd3dDevice->basicShader->Begin();
@@ -1103,9 +1106,13 @@ void Surface::RenderWallsAtHeight(const bool drop)
          pd3dDevice->basicShader->SetTechniqueMetal(SHADER_TECHNIQUE_basic_with_texture, mat->m_bIsMetal);
          pd3dDevice->basicShader->SetTexture(SHADER_tex_base_color, pin);
          pd3dDevice->basicShader->SetAlphaTestValue(pin->m_alphaTestValue * (float)(1.0 / 255.0));
+         pd3dDevice->basicShader->SetMaterial(mat, pin->m_pdsBuffer->has_alpha());
       }
       else
+      {
          pd3dDevice->basicShader->SetTechniqueMetal(SHADER_TECHNIQUE_basic_without_texture, mat->m_bIsMetal);
+         pd3dDevice->basicShader->SetMaterial(mat, false);
+      }
 
       // Top
       pd3dDevice->basicShader->Begin();

--- a/trigger.cpp
+++ b/trigger.cpp
@@ -606,7 +606,7 @@ void Trigger::RenderDynamic()
 
    const Material * const mat = m_ptable->GetMaterial(m_d.m_szMaterial);
    pd3dDevice->basicShader->SetTechniqueMetal(SHADER_TECHNIQUE_basic_without_texture, mat->m_bIsMetal);
-   pd3dDevice->basicShader->SetMaterial(mat);
+   pd3dDevice->basicShader->SetMaterial(mat, false);
 
    pd3dDevice->SetRenderStateDepthBias(0.0f);
    pd3dDevice->SetRenderState(RenderDevice::ZWRITEENABLE, RenderDevice::RS_TRUE);


### PR DESCRIPTION
Multiple commits covering a few different issues or improvments:
- fix some native memory leaks
- port fix proprty dialogs from VPX (image combobox and drag point edit)
- render state cleanup (less state changes, clean alpha setting, more consistent between GL and DX)
- optimizations: when texture has no alpha channel, then don't blend, don't render the bulb mesh to light buffer, use RGB rendertarget when RGBA is not needed