### PR TITLE
SMAA & fixes

### DIFF
--- a/RenderDevice.h
+++ b/RenderDevice.h
@@ -25,8 +25,8 @@ void ReportError(const char *errorText, const HRESULT hr, const char *file, cons
 
 #if 1//def _DEBUG
 #ifdef ENABLE_SDL
-//void checkGLErrors(const char *file, const int line);
-//#define CHECKD3D(s) { s; } //checkGLErrors(__FILE__, __LINE__); } // by now the callback is used instead
+void checkGLErrors(const char *file, const int line);
+#define CHECKD3D(s) { s; } //checkGLErrors(__FILE__, __LINE__); }
 #else //ENABLE_SDL
 #define CHECKD3D(s) { const HRESULT hrTmp = (s); if (FAILED(hrTmp)) ReportFatalError(hrTmp, __FILE__, __LINE__); }
 #endif
@@ -185,11 +185,12 @@ public:
 
    bool SetMaximumPreRenderedFrames(const DWORD frames);
 
-   RenderTarget* GetMSAABackBufferTexture() const { return m_pOffscreenMSAABackBufferTexture; } // Main render target, may be MSAA enabled and not suited for sampling
+   RenderTarget* GetMSAABackBufferTexture() const { return m_pOffscreenMSAABackBufferTexture; } // Main render target, may be MSAA enabled and not suited for sampling, also may have stereo output (2 viewports)
    void ResolveMSAA(); // Resolve MSAA back buffer texture to be sample  from back buffer texture
-   RenderTarget* GetBackBufferTexture() const { return m_pOffscreenBackBufferTexture; } // Main render target, with MSAA resolved if any
-   RenderTarget* GetBackBufferTmpTexture() const { return m_pOffscreenBackBufferTmpTexture; } // stereo/FXAA only
-   RenderTarget* GetBackBufferTmpTexture2() const { return m_pOffscreenBackBufferTmpTexture2; } // SMAA only
+   RenderTarget* GetBackBufferTexture() const { return m_pOffscreenBackBufferTexture; } // Main render target, with MSAA resolved if any, also may have stereo output (2 viewports)
+   RenderTarget* GetBackBufferTmpTexture() const { return m_pOffscreenBackBufferTmpTexture; } // sharpen, stereo & FXAA
+   RenderTarget* GetBackBufferTmpTexture2() const { return m_pOffscreenBackBufferTmpTexture2; } // sharpen & SMAA
+   RenderTarget* GetPostProcessTexture(RenderTarget* renderedRT) const { return renderedRT == m_pOffscreenBackBufferTmpTexture ? m_pOffscreenBackBufferTmpTexture2 : m_pOffscreenBackBufferTmpTexture; }
    RenderTarget* GetOffscreenVR(int eye) const { return eye == 0 ? m_pOffscreenVRLeft : m_pOffscreenVRRight; }
    RenderTarget* GetMirrorTmpBufferTexture() const { return m_pMirrorTmpBufferTexture; }
    RenderTarget* GetReflectionBufferTexture() const { return m_pReflectionBufferTexture; }

--- a/RenderTarget.h
+++ b/RenderTarget.h
@@ -10,7 +10,7 @@ public:
    RenderTarget(RenderDevice* rd, const int width, const int height, const colorFormat format, bool with_depth, int nMSAASamples, StereoMode stereo, char* failureMessage);
    ~RenderTarget();
 
-   void Activate(const bool ignoreStereo);
+   void Activate(const bool ignoreStereo = false);
    static RenderTarget* GetCurrentRenderTarget();
 
    Sampler* GetColorSampler() { return m_color_sampler; }
@@ -20,7 +20,7 @@ public:
    RenderTarget* Duplicate();
    void CopyTo(RenderTarget* dest);
 
-   void SetSize(const int w, const int h) { m_width = w;  m_height = h; }
+   void SetSize(const int w, const int h) { assert(m_is_back_buffer); m_width = w; m_height = h; }
    int GetWidth() const { return m_width; }
    int GetHeight() const { return m_height; }
    StereoMode GetStereo() const { return m_stereo; }

--- a/Shader.cpp
+++ b/Shader.cpp
@@ -179,8 +179,8 @@ Shader::ShaderUniform Shader::shaderUniformNames[SHADER_UNIFORM_COUNT] {
    SHADER_SAMPLER(tex_stereo_fb, texSampler0, Texture0, 0, SA_CLAMP, SA_CLAMP, SF_POINT), // Framebuffer (unfiltered)
    // SMAA shader
    // FIXME SMAA shader also use the color and colorGamma samplers. This has to be looked at more deeply for a clean implementation
-   SHADER_SAMPLER(smaa_colorTex, colorTex, colorTex, 0, SA_CLAMP, SA_CLAMP, SF_TRILINEAR),
-   SHADER_SAMPLER(smaa_colorGammaTex, colorGammaTex, colorGammaTex, 1, SA_CLAMP, SA_CLAMP, SF_TRILINEAR),
+   SHADER_SAMPLER(colorTex, colorTex, colorTex, 0, SA_CLAMP, SA_CLAMP, SF_TRILINEAR),
+   SHADER_SAMPLER(colorGammaTex, colorGammaTex, colorGammaTex, 1, SA_CLAMP, SA_CLAMP, SF_TRILINEAR),
    SHADER_SAMPLER(edgesTex, edgesTex, edgesTex2D, 2, SA_CLAMP, SA_CLAMP, SF_TRILINEAR),
    SHADER_SAMPLER(blendTex, blendTex, blendTex2D, 3, SA_CLAMP, SA_CLAMP, SF_TRILINEAR),
    SHADER_SAMPLER(areaTex, areaTex, areaTex2D, 4, SA_CLAMP, SA_CLAMP, SF_TRILINEAR),

--- a/Shader.h
+++ b/Shader.h
@@ -186,8 +186,8 @@ enum ShaderUniforms
    SHADER_SAMPLER(tex_stereo_fb, texSampler0, Texture0, 0, SA_CLAMP, SA_CLAMP, SF_POINT), // Framebuffer (unfiltered)
    // SMAA shader
    // FIXME SMAA shader also use the color and colorGamma samplers. This has to be looked at more deeply for a clean implementation
-   SHADER_SAMPLER(smaa_colorTex, colorTex, colorTex, 0, SA_CLAMP, SA_CLAMP, SF_TRILINEAR),
-   SHADER_SAMPLER(smaa_colorGammaTex, colorGammaTex, colorGammaTex, 1, SA_CLAMP, SA_CLAMP, SF_TRILINEAR),
+   SHADER_SAMPLER(colorTex, colorTex, colorTex, 0, SA_CLAMP, SA_CLAMP, SF_TRILINEAR),
+   SHADER_SAMPLER(colorGammaTex, colorGammaTex, colorGammaTex, 1, SA_CLAMP, SA_CLAMP, SF_TRILINEAR),
    SHADER_SAMPLER(edgesTex, edgesTex, edgesTex2D, 2, SA_CLAMP, SA_CLAMP, SF_TRILINEAR),
    SHADER_SAMPLER(blendTex, blendTex, blendTex2D, 3, SA_CLAMP, SA_CLAMP, SF_TRILINEAR),
    SHADER_SAMPLER(areaTex, areaTex, areaTex2D, 4, SA_CLAMP, SA_CLAMP, SF_TRILINEAR),

--- a/ShaderGL.cpp
+++ b/ShaderGL.cpp
@@ -601,7 +601,7 @@ uint32_t Shader::CopyUniformCache(const bool copyTo, const ShaderTechniques tech
          memcpy(dst->data, src->data, src->count * sizeof(float));
       }
       if (shaderUniformNames[uniformName].is_sampler)
-         sampler_hash += (uint32_t) src->val.sampler;
+         sampler_hash += (unsigned long) src->val.sampler;
    }
    return sampler_hash;
 }

--- a/glshader/FBShader.glfx
+++ b/glshader/FBShader.glfx
@@ -188,9 +188,9 @@ out vec2 tex0;
 
 void main()
 { 
-   gl_Position = vec4(vPosition.x,-vPosition.y,0.0,1.0);
+   gl_Position = vec4(vPosition.x, vPosition.y,0.0,1.0);
    // Offset texture coordinates since OpenGL texel center is shifted by half a texel from DirectX texel center
-   tex0 = tc - w_h_height.xy*0.5;
+   tex0 = vec2(tc.x-0.5*w_h_height.x, 1.0-tc.y-0.5*w_h_height.y);
 }
 
 ////ps_main_fb_tonemap

--- a/glshader/SMAA.glfx
+++ b/glshader/SMAA.glfx
@@ -87,8 +87,11 @@ out vec4[3] offset;
 
 void main()
 {
-    gl_Position = vec4(2.0*vPosition.x-1.0,2.0*vPosition.y-1.0, 0.0,1.0);
-    texcoord = vec2(tc.x,1.0-tc.y) + w_h_height.xy*0.5;
+    gl_Position = vec4(vPosition.x,-vPosition.y,0.0,1.0);
+    //gl_Position = vec4(2.0*vPosition.x-1.0,2.0*vPosition.y-1.0, 0.0,1.0);
+    // Offset texture coordinates since OpenGL texel center is shifted by half a texel from DirectX texel center
+    //texcoord = vec2(tc.x,1.0-tc.y) + w_h_height.xy*0.5;
+    texcoord = tc;
     SMAAEdgeDetectionVS(texcoord, offset);
 }
 
@@ -103,8 +106,11 @@ out vec2 pixcoord;
 
 void main()
 {
-    gl_Position = vec4(2.0*vPosition.x-1.0,2.0*vPosition.y-1.0, 0.0,1.0);
-    texcoord = vec2(tc.x,1.0-tc.y) + w_h_height.xy*0.5;
+    gl_Position = vec4(vPosition.x,-vPosition.y,0.0,1.0);
+    //gl_Position = vec4(2.0*vPosition.x-1.0,2.0*vPosition.y-1.0, 0.0,1.0);
+    // Offset texture coordinates since OpenGL texel center is shifted by half a texel from DirectX texel center
+    //texcoord = vec2(tc.x,1.0-tc.y) + w_h_height.xy*0.5;
+    texcoord = tc;
     SMAABlendingWeightCalculationVS(texcoord, pixcoord, offset);
 }
 
@@ -118,8 +124,11 @@ out vec4 offset;
 
 void main()
 {
-    gl_Position = vec4(2.0*vPosition.x-1.0,2.0*vPosition.y-1.0, 0.0,1.0);
-    texcoord = vec2(tc.x,1.0-tc.y) + w_h_height.xy*0.5;
+    gl_Position = vec4(vPosition.x,-vPosition.y,0.0,1.0);
+    // gl_Position = vec4(2.0*vPosition.x-1.0,2.0*vPosition.y-1.0, 0.0,1.0);
+    // Offset texture coordinates since OpenGL texel center is shifted by half a texel from DirectX texel center
+    //texcoord = vec2(tc.x,1.0-tc.y) + w_h_height.xy*0.5;
+    texcoord = tc;
     SMAANeighborhoodBlendingVS(texcoord, offset);
 }
 

--- a/glshader/StereoShader.glfx
+++ b/glshader/StereoShader.glfx
@@ -116,8 +116,8 @@ out vec4 color;
 
 void main()
 {
-   gl_Position = vec4(vPosition.x, -vPosition.y, 0.0, 1.0);
-   tex0 = float2(tc.x, tc.y);
+   gl_Position = vec4(vPosition.x, vPosition.y, 0.0, 1.0);
+   tex0 = float2(tc.x, 1.0-tc.y);
 }
 
 ////ps_main_int
@@ -138,8 +138,8 @@ void main()
 
 void main()
 {
-   gl_Position = vec4(vPosition.x*2.0-1.0, 1.0-vPosition.y*2.0, 0.0,1.0);
-   tex0 = float2(tc.x, tc.y);
+   gl_Position = vec4(vPosition.x, vPosition.y, 0.0, 1.0);
+   tex0 = float2(tc.x, 1.0-tc.y);
 }
 
 ////ps_main_amd

--- a/pin3d.cpp
+++ b/pin3d.cpp
@@ -589,9 +589,9 @@ HRESULT Pin3D::InitPin3D(const bool fullScreen, const int width, const int heigh
 
    // Direct all renders to the "static" buffer.
    if (m_pddsStatic)
-      m_pddsStatic->Activate(true);
+      m_pddsStatic->Activate();
    else
-      m_pd3dPrimaryDevice->GetBackBufferTexture()->Activate(true);
+      m_pd3dPrimaryDevice->GetMSAABackBufferTexture()->Activate();
 
    //m_gpu_profiler.Init(m_pd3dDevice->GetCoreDevice()); // done by first BeginFrame() call lazily
 


### PR DESCRIPTION
A bunch of fixes:
- SMAA is back
- Fix positionning the player window (through toggling title bar for dragging)
- Cleanup output buffer size, which fixes some bugs when redenring/previewing stereo
- Cleanup postprocess buffer use
- As much as possible perform postprocess using RGB8/RGB10 instead of RGB16F