### PR TITLE
BW textures

### DIFF
--- a/Sampler.cpp
+++ b/Sampler.cpp
@@ -27,6 +27,8 @@ Sampler::Sampler(RenderDevice* rd, BaseTexture* const surf, const bool force_lin
       format = colorFormat::RGB16F;
    else if (surf->m_format == BaseTexture::RGB_FP32)
       format = colorFormat::RGB32F;
+   else if (surf->m_format == BaseTexture::BW)
+      format = colorFormat::GREY8;
    else
       assert(false); // Unsupported image format
    if (force_linear_rgb)
@@ -141,6 +143,8 @@ void Sampler::UpdateTexture(BaseTexture* const surf, const bool force_linear_rgb
       format = colorFormat::RGB16F;
    else if (surf->m_format == BaseTexture::RGB_FP32)
       format = colorFormat::RGB32F;
+   else if (surf->m_format == BaseTexture::BW)
+      format = colorFormat::GREY8;
    else
       assert(false);
    if (force_linear_rgb)

--- a/Texture.h
+++ b/Texture.h
@@ -10,21 +10,20 @@ class BaseTexture final
 public:
    enum Format
    { // RGB/RGBA formats must be ordered R, G, B (and eventually A)
-      RGB,			// Linear RGB without alpha channel, 1 byte per channel
+      BW,         // Linear BW image, 1 byte per texel
+      RGB,        // Linear RGB without alpha channel, 1 byte per channel
       RGBA,			// Linear RGB with alpha channel, 1 byte per channel
       SRGB,			// sRGB without alpha channel, 1 byte per channel
       SRGBA,		// sRGB with alpha channel, 1 byte per channel
-      RGB_FP16,		// Linear RGB, 1 half float per channel
+      RGB_FP16,	// Linear RGB, 1 half float per channel
       RGB_FP32		// Linear RGB, 1 float per channel
    };
 
-   BaseTexture(const unsigned int w, const unsigned int h, const Format format)
-      : m_width(w), m_height(h), m_data((format == RGBA || format == SRGBA ? 4 : 3) * (format == RGB_FP32 ? 4 : format == RGB_FP16 ? 2 : 1) * w * h), m_realWidth(w), m_realHeight(h), m_format(format)
-   { }
+   BaseTexture(const unsigned int w, const unsigned int h, const Format format);
 
    unsigned int width() const  { return m_width; }
    unsigned int height() const { return m_height; }
-   unsigned int pitch() const  { return (has_alpha() ? 4 : 3) * (m_format == RGB_FP32 ? 4 : m_format == RGB_FP16 ? 2 : 1) * m_width; } // pitch in bytes
+   unsigned int pitch() const  { return (m_format == BW ? 1 : (has_alpha() ? 4 : 3)) * (m_format == RGB_FP32 ? 4 : m_format == RGB_FP16 ? 2 : 1) * m_width; } // pitch in bytes
    BYTE* data()                { return m_data.data(); }
    bool has_alpha() const      { return m_format == RGBA || m_format == SRGBA; }
 

--- a/pin3d.cpp
+++ b/pin3d.cpp
@@ -964,6 +964,9 @@ void Pin3D::InitLayout(const bool FSS_mode, const float max_separation, const fl
    m_proj.ComputeNearFarPlane(vvertex3D);
    if (fabsf(inclination) < 0.0075f) //!! magic threshold, otherwise kicker holes are missing for inclination ~0
       m_proj.m_rzfar += 10.f;
+   //!! TODO magic: In stereo, we usually have a room made of primitives, but primitive bounding box are not implemented and are not taken in account. So add some space
+   if (m_stereo3D != STEREO_OFF) 
+      m_proj.m_rzfar += 5000.f;
    Matrix3D proj = Matrix3D::MatrixPerspectiveFovLH(ANGTORAD(FOV), aspect, m_proj.m_rznear, m_proj.m_rzfar);
 
 //   memcpy(m_proj.m_matProj.m, proj.m, sizeof(float) * 4 * 4);
@@ -1321,11 +1324,15 @@ void PinProjection::ComputeNearFarPlane(const vector<Vertex3Ds>& verts)
    slintf("m_rznear: %f\n", m_rznear);
    slintf("m_rzfar : %f\n", m_rzfar);
 
-   // beware the div-0 problem, also avoid near plane below 1 which result in loss of precision and z rendering artefacts
+   //m_rznear *= 0.89f; //!! magic, influences also stereo3D code
+   // Avoid near plane below 1 which result in loss of precision and z rendering artefacts
    if (m_rznear < 1.0f)
       m_rznear = 1.0f;
-   //m_rznear *= 0.89f; //!! magic, influences also stereo3D code
+
    m_rzfar *= 1.01f;
+   // Avoid div-0 problem (div by far - near)
+   if (m_rzfar <= m_rznear)
+      m_rzfar = m_rznear + 1.0f;
 }
 
 void PinProjection::CacheTransform()

--- a/pintable.cpp
+++ b/pintable.cpp
@@ -6915,6 +6915,10 @@ int PinTable::AddListImage(HWND hwndListView, Texture * const ppi)
    {
       ListView_SetItemText(hwndListView, index, 5, "-");
    }
+   else if (ppi->m_pdsBuffer->m_format == BaseTexture::BW)
+   {
+      ListView_SetItemText(hwndListView, index, 5, "BW");
+   }
    else if (ppi->m_pdsBuffer->m_format == BaseTexture::SRGB)
    {
       ListView_SetItemText(hwndListView, index, 5, "sRGB");


### PR DESCRIPTION
Add linear BW textures. They are needed:
- some tables do have some (like VPW Indiana Jones)
- they makes things more clean for SMAA

These are for linear BW. When loaded from a file, we convert them to sRGB since they are in fact 'sBW' (in sRGB colorspace).