### PR TITLE
Fix postprocess

### DIFF
--- a/RenderDevice.cpp
+++ b/RenderDevice.cpp
@@ -1827,7 +1827,7 @@ GLuint RenderDevice::GetSamplerState(SamplerFilter filter, SamplerAddressMode cl
       m_curStateChanges += 5;
       glGenSamplers(1, &sampler_state);
       m_samplerStateCache[samplerStateId] = sampler_state;
-      constexpr int glAddress[] = { GL_REPEAT, GL_REPEAT, GL_CLAMP_TO_EDGE, GL_MIRRORED_REPEAT };
+      constexpr int glAddress[] = { GL_REPEAT, GL_CLAMP_TO_EDGE, GL_MIRRORED_REPEAT, GL_REPEAT };
       glSamplerParameteri(sampler_state, GL_TEXTURE_WRAP_S, glAddress[clamp_u]);
       glSamplerParameteri(sampler_state, GL_TEXTURE_WRAP_T, glAddress[clamp_v]);
       switch (filter)

--- a/pin/player.h
+++ b/pin/player.h
@@ -542,7 +542,7 @@ public:
    U32 m_LastPlungerHit;		// The last time the plunger was in contact (at least the vicinity) of the ball.
    float m_curMechPlungerPos;
 
-   int m_width, m_height;
+   int m_wnd_width, m_wnd_height; // Window height (requested size before creation, effective size after) which is not directly linked to the render size
    int m_display;
 
    int m_screenwidth, m_screenheight, m_refreshrate;

--- a/pintable.cpp
+++ b/pintable.cpp
@@ -804,14 +804,14 @@ STDMETHODIMP ScriptGlobalTable::MaterialColor(BSTR pVal, OLE_COLOR newVal)
 STDMETHODIMP ScriptGlobalTable::get_WindowWidth(int *pVal)
 {
    if (g_pplayer)
-      *pVal = g_pplayer->m_width;
+      *pVal = g_pplayer->m_wnd_width;
    return S_OK;
 }
 
 STDMETHODIMP ScriptGlobalTable::get_WindowHeight(int *pVal)
 {
    if (g_pplayer)
-      *pVal = g_pplayer->m_height;
+      *pVal = g_pplayer->m_wnd_height;
    return S_OK;
 }
 

--- a/textbox.cpp
+++ b/textbox.cpp
@@ -321,7 +321,7 @@ void Textbox::RenderSetup()
 
    CY size;
    m_pIFontPlay->get_Size(&size);
-   size.int64 = (LONGLONG)(size.int64 / 1.5 * g_pplayer->m_height * g_pplayer->m_width);
+   size.int64 = (LONGLONG)(size.int64 / 1.5 * g_pplayer->m_wnd_height * g_pplayer->m_wnd_width);
    m_pIFontPlay->put_Size(size);
 
    PreRenderText();
@@ -388,7 +388,7 @@ void Textbox::PreRenderText()
       break;
    }
 
-   const int border = (4 * g_pplayer->m_width) / EDITOR_BG_WIDTH;
+   const int border = (4 * g_pplayer->m_wnd_width) / EDITOR_BG_WIDTH;
    RECT rcOut;
    rcOut.left = border;
    rcOut.top = border;


### PR DESCRIPTION
Finally fix the remaining artefact to the postprocess. Hopefully this is fully working with everything from VPX matching.
Beside a stupid mistake regarding sampler address mode, the big issue was that VPX takes for granted that window size match render size which is fully wrong in VR (the preview window size is not linked to the render size). This PR fixes it
